### PR TITLE
[feat] 엔티티 생성 및 연관관계 매핑

### DIFF
--- a/src/main/java/com/pitchain/common/entity/BaseEntity.java
+++ b/src/main/java/com/pitchain/common/entity/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.pitchain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public abstract class BaseEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -1,0 +1,53 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bm_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private BmCategory category;
+
+    private String logoImg;
+
+    @Column(length = 10000)
+    private String description;
+
+    private String descriptionImg;
+    private String address;
+    private Long valuationCap;
+    private LocalDate deadline;
+    private String longPitchUrl;
+
+    @OneToMany(mappedBy = "bm")
+    private List<Investment> investments = new ArrayList<>();
+
+    @OneToOne(mappedBy = "bm")
+    private Sp sp;
+
+    @OneToMany(mappedBy = "bm")
+    private List<PtImg> ptImgs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "bm")
+    private List<BmTag> bmTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "bm")
+    private List<Comment> comments = new ArrayList<>();
+}

--- a/src/main/java/com/pitchain/entity/BmCategory.java
+++ b/src/main/java/com/pitchain/entity/BmCategory.java
@@ -1,0 +1,5 @@
+package com.pitchain.entity;
+
+public enum BmCategory {
+    DEEP_TECH,
+}

--- a/src/main/java/com/pitchain/entity/BmTag.java
+++ b/src/main/java/com/pitchain/entity/BmTag.java
@@ -1,0 +1,24 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BmTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bm_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+    @Column(nullable = false)
+    private String tag;
+}

--- a/src/main/java/com/pitchain/entity/Comment.java
+++ b/src/main/java/com/pitchain/entity/Comment.java
@@ -1,0 +1,42 @@
+package com.pitchain.entity;
+
+import com.pitchain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "top_comment_id")
+    private Comment topComment;
+
+    @OneToMany(mappedBy = "topComment")
+    private List<Comment> underComments = new ArrayList<>();
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "del_yn")
+    private boolean delYN;
+}

--- a/src/main/java/com/pitchain/entity/Country.java
+++ b/src/main/java/com/pitchain/entity/Country.java
@@ -1,0 +1,5 @@
+package com.pitchain.entity;
+
+public enum Country {
+    ROK,
+}

--- a/src/main/java/com/pitchain/entity/Investment.java
+++ b/src/main/java/com/pitchain/entity/Investment.java
@@ -1,0 +1,33 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Investment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "investment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+    private long amount;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/pitchain/entity/Investment.java
+++ b/src/main/java/com/pitchain/entity/Investment.java
@@ -1,17 +1,15 @@
 package com.pitchain.entity;
 
+import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Investment {
+public class Investment  extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,7 +25,4 @@ public class Investment {
     private Bm bm;
 
     private long amount;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -1,0 +1,43 @@
+package com.pitchain.entity;
+
+import com.pitchain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {@UniqueConstraint(name = "EMAIL_UNIQUE", columnNames = {"email"})})
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Country country;
+
+    @OneToMany(mappedBy = "member")
+    private List<Investment> investments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MyCategory> myCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MyBm> myBms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Comment> comments = new ArrayList<>();
+}

--- a/src/main/java/com/pitchain/entity/MyBm.java
+++ b/src/main/java/com/pitchain/entity/MyBm.java
@@ -1,0 +1,26 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyBm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "my_bm_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+}

--- a/src/main/java/com/pitchain/entity/MyCategory.java
+++ b/src/main/java/com/pitchain/entity/MyCategory.java
@@ -1,0 +1,24 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "my_category_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private BmCategory category;
+}

--- a/src/main/java/com/pitchain/entity/PtImg.java
+++ b/src/main/java/com/pitchain/entity/PtImg.java
@@ -1,0 +1,27 @@
+package com.pitchain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PtImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pt_img_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+    private int serialNum;
+
+    @Column(nullable = false)
+    private String img;
+
+}

--- a/src/main/java/com/pitchain/entity/Sp.java
+++ b/src/main/java/com/pitchain/entity/Sp.java
@@ -1,0 +1,30 @@
+package com.pitchain.entity;
+
+import com.pitchain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sp extends BaseEntity {
+
+    @Id
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bm_id", nullable = false)
+    private Bm bm;
+
+    @Column(nullable = false)
+    private String shortPitchURL;
+
+    @Column(nullable = false)
+    private String thumbnailImg;
+
+    private int views;
+
+    @Column(nullable = false)
+    private String description;
+
+}


### PR DESCRIPTION
## ⭐ Summary
> #8 

엔티티 생성 및 연관관계 매핑

<br>

## 📌 Tasks

1. 식별 관계 및 복합 키 -> 비식별 관계 및 대체 키로 설정
2. BM투자 테이블 이름을 investment로 수정: 자금 조달인 funding보다는 개인 투자라는 행위에 의미가 더 맞는 것 같아서 investment로 수정했습니다.
3. 테이블 BM에서 최소투자금액, 최대투자금액 삭제: 생각해보니 필드를 따로 둘 게 아니라 BM투자 테이블을 조회해서 실시간으로 최소/최대 투자금액을 계산하는 로직이 필요해서 해당 필드들은 삭제했습니다. 

<br>

## ETC

@IdClass를 이용해서 복합 키를 구현해보려고 했는데 저희가 설계한 ERD에 딱 맞는 방법을 아직 못 찾았습니다...ㅜ 그리고 찾아보면 찾아볼수록 jpa는 확실히 식별 관계의 복합 키 보다는 대체 키를 사용하는 것이 더 수월하다고 느껴지더라고요. 또 BM투자의 경우는 한 BM에 사용자가 여러 번 투자할 수 있다는 가정이 있어서 애초에 식별 관계가 불가했습니다. 이러한 여러 가지 이유로 BM과 일대일 관계인 SP 테이블을 제외하고 auto increment 대체 키를 모두 넣어줬습니다. ERD도 수정했으니 확인 부탁드립니다!
