### PR TITLE
[Feat] API payload 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.yml ###
+/src/main/resources/application*.yml

--- a/src/main/java/com/pitchain/common/apiPayload/dto/CustomApiResponse.java
+++ b/src/main/java/com/pitchain/common/apiPayload/dto/CustomApiResponse.java
@@ -1,0 +1,39 @@
+package com.pitchain.common.apiPayload.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.pitchain.common.apiPayload.statusEnums.SuccessStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"isSuccess", "code", "message", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CustomApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    private final String code;
+
+    private final String message;
+
+    private T data;
+
+    // 성공 응답
+    public static <T> CustomApiResponse<T> onSuccess(){
+        return new CustomApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), null);
+    }
+
+    public static <T> CustomApiResponse<T> onSuccess(T result){
+        return new CustomApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    // 실패 응답
+    public static <T> CustomApiResponse<T> onFailure(String code, String message, T data){
+        return new CustomApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/pitchain/common/apiPayload/dto/ResponseDTO.java
+++ b/src/main/java/com/pitchain/common/apiPayload/dto/ResponseDTO.java
@@ -1,0 +1,17 @@
+package com.pitchain.common.apiPayload.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@Builder
+public class ResponseDTO {
+
+    private final boolean isSuccess;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
@@ -1,0 +1,40 @@
+package com.pitchain.common.apiPayload.statusEnums;
+
+import com.pitchain.common.apiPayload.dto.ResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements ResponseStatus {
+
+    // common
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ResponseDTO getDto() {
+        return ResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ResponseDTO getHttpStatusDto() {
+        return ResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ResponseStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ResponseStatus.java
@@ -1,0 +1,11 @@
+package com.pitchain.common.apiPayload.statusEnums;
+
+import com.pitchain.common.apiPayload.dto.ResponseDTO;
+
+public interface ResponseStatus {
+
+    public ResponseDTO getDto();
+
+    public ResponseDTO getHttpStatusDto();
+
+}

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/SuccessStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.pitchain.common.apiPayload.statusEnums;
+
+import com.pitchain.common.apiPayload.dto.ResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements ResponseStatus {
+
+    // 일반적인 성공 응답
+    _OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ResponseDTO getDto() {
+        return ResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ResponseDTO getHttpStatusDto() {
+        return ResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/exception/ExceptionAdvice.java
+++ b/src/main/java/com/pitchain/exception/ExceptionAdvice.java
@@ -1,0 +1,132 @@
+package com.pitchain.exception;
+
+import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.common.apiPayload.dto.ResponseDTO;
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    // Bean Validation API를 통한 검증 실패 시 호출
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    // @Valid 어노테이션으로 검증 실패 시 호출
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    // IllegalArgumentException 처리
+    @ExceptionHandler
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e, WebRequest request) {
+        log.error("IllegalArgumentException occurred: {}", e.getMessage(), e);
+        return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request, e.getMessage());
+    }
+
+    // 일반적인 Exception 처리
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    // GeneralHandler 타입의 예외 처리(커스텀 예외 처리)
+    @ExceptionHandler(value = GeneralHandler.class)
+    public ResponseEntity onThrowException(GeneralHandler generalHandler, HttpServletRequest request) {
+        ResponseDTO errorHttpStatus = generalHandler.getErrorHttpStatus();
+        return handleExceptionInternal(generalHandler, errorHttpStatus, null, request);
+    }
+
+    // 예외와 에러 상태를 받아 ResponseEntity 생성
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ResponseDTO error,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        CustomApiResponse<Object> body = CustomApiResponse.onFailure(error.getCode(), error.getMessage(), null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                error.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    // 예외와 에러 상태, 추가 정보를 받아 ResponseEntity 생성
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        CustomApiResponse<Object> body = CustomApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    // 예외와 에러 상태, 에러 메시지 Map을 받아 ResponseEntity 생성
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        CustomApiResponse<Object> body = CustomApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    // 예외와 에러 상태를 받아 ResponseEntity 생성, 에러 정보는 null로 설정
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        CustomApiResponse<Object> body = CustomApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+}

--- a/src/main/java/com/pitchain/exception/GeneralHandler.java
+++ b/src/main/java/com/pitchain/exception/GeneralHandler.java
@@ -1,0 +1,24 @@
+package com.pitchain.exception;
+
+import com.pitchain.common.apiPayload.dto.ResponseDTO;
+import com.pitchain.common.apiPayload.statusEnums.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class GeneralHandler extends RuntimeException {
+
+    private ResponseStatus errorStatus;
+
+    public GeneralHandler(ResponseStatus errorStatus) {
+        super(errorStatus.getDto().getMessage());
+        this.errorStatus = errorStatus;
+    }
+
+    public ResponseDTO getError() {
+        return this.errorStatus.getDto();
+    }
+
+    public ResponseDTO getErrorHttpStatus() {
+        return this.errorStatus.getHttpStatusDto();
+    }
+}


### PR DESCRIPTION
## ⭐ Summary

> #22 

<br>

## 📌 Tasks

1. API payload 구현

<br>

## ETC
### CustomApiResponse 활용
Controller에서는 반환해줄 때 CustomApiResponse.onSuccess()를 활용하면 되고 
API 로직에서 에러가 발생하면 Advice로 잡아서 CustomApiResponse.onFailure()를 반환하게 구현되어 있어서 
사실상 CustomApiResponse.onSuccess()만 활용하시면 됩니다

### GeneralHandler, ErrorStatus 활용
- 예외처리 시 GeneralHandler(ErrorStatus status)를 반환
- 에러는 ErrorStatus에 정의하여 사용
- ErrorStatus의 code값은 domain명 + httpcode + sequence
  - ex)
  ```  java
  // member
  DUPLICATED_MEMBER_ID(HttpStatus.UNAUTHORIZED, "MEMBER4011", "이미 존재하는 사용자 ID입니다."),
  INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER4012", "사용자 비밀번호가 일치하지 않습니다"),
  MEMBER_FORBIDDEN(HttpStatus.FORBIDDEN, "MEMBER4031", "사용자에게 권한이 없습니다."),
  GUEST_ROLE_FORBIDDEN(HttpStatus.FORBIDDEN, "MEMBER4032", "게스트 회원은 이용할 수 없는 기능입니다.")
  ```
