### PR TITLE
[feat] JWT 검증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // JWT
+    implementation 'com.auth0:java-jwt:4.2.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
@@ -13,7 +13,10 @@ public enum ErrorStatus implements ResponseStatus {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // jwt
+    MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4012", "Access Token이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/pitchain/common/config/RedisConfig.java
+++ b/src/main/java/com/pitchain/common/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.pitchain.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    // (refreshToken, memberId)
+    @Bean
+    public RedisTemplate<String, Long> StringLongRedisTemplate() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Long.class));
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/pitchain/common/config/SecurityConfig.java
+++ b/src/main/java/com/pitchain/common/config/SecurityConfig.java
@@ -1,22 +1,58 @@
 package com.pitchain.common.config;
 
+import com.pitchain.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()  //Swagger
-                        .anyRequest().permitAll());
-
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable);
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(JwtAuthenticationFilter.whitelist);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(Arrays.asList("Authorization", "Authorization-Refresh"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/pitchain/common/config/SwaggerConfig.java
+++ b/src/main/java/com/pitchain/common/config/SwaggerConfig.java
@@ -12,12 +12,27 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI pitchainOpenAPI() {
         return new OpenAPI()
-                .info(new Info().title("Pitchain API")
-                                .version("v0.0.1")
-                )
+                // swagger에서 jwt 활용하기 위한 설정
+//                .components(new Components()
+//                        .addSecuritySchemes(
+//                                AUTHORIZATION,
+//                                new SecurityScheme()
+//                                        .name(AUTHORIZATION)
+//                                        .type(HTTP)
+//                                        .scheme("Bearer")
+//                                        .bearerFormat(JWT))
+//                )
+//                .addSecurityItem(new SecurityRequirement().addList(AUTHORIZATION))
                 .externalDocs(new ExternalDocumentation()
                         .description("Pitchain Server Github")
-                        .url("https://github.com/Young-Flow/server"));
+                        .url("https://github.com/Young-Flow/server"))
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Pitchain API")
+                .version("v0.0.1");
     }
 
 }

--- a/src/main/java/com/pitchain/common/constant/TokenType.java
+++ b/src/main/java/com/pitchain/common/constant/TokenType.java
@@ -1,0 +1,5 @@
+package com.pitchain.common.constant;
+
+public enum TokenType {
+    ACCESS_TOKEN, REFRESH_TOKEN
+}

--- a/src/main/java/com/pitchain/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/pitchain/common/exception/ExceptionAdvice.java
@@ -1,4 +1,4 @@
-package com.pitchain.exception;
+package com.pitchain.common.exception;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
 import com.pitchain.common.apiPayload.dto.ResponseDTO;

--- a/src/main/java/com/pitchain/common/exception/GeneralHandler.java
+++ b/src/main/java/com/pitchain/common/exception/GeneralHandler.java
@@ -1,4 +1,4 @@
-package com.pitchain.exception;
+package com.pitchain.common.exception;
 
 import com.pitchain.common.apiPayload.dto.ResponseDTO;
 import com.pitchain.common.apiPayload.statusEnums.ResponseStatus;

--- a/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
@@ -39,12 +39,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = tokenUtil.extractToken(request, TokenType.ACCESS_TOKEN);
 
-        if (token == null) {
-            log.error("Access token is missing");
-            throw new GeneralHandler(ErrorStatus.MISSING_ACCESS_TOKEN);
-        }
-
         // jwt 검증 로직
+//        if (token == null) {
+//            log.error("Access token is missing");
+//            throw new GeneralHandler(ErrorStatus.MISSING_ACCESS_TOKEN);
+//        }
+//
 //        DecodedJWT decodedJWT = tokenUtil.decodedJWT(token);
 //        Long id = decodedJWT.getClaim("id").asLong();
 //        Authentication authentication = new UsernamePasswordAuthenticationToken(id,null);

--- a/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.pitchain.jwt;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.TokenType;
+import com.pitchain.common.exception.GeneralHandler;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenUtil tokenUtil;
+
+    public static final String[] whitelist = {
+            "/oauth**",
+            "/resources/**", "/favicon.ico", // resource
+            "/swagger-ui/**", "/api-docs/**", "/v3/api-docs**", "/v3/api-docs/**" , // swagger
+    };
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return PatternMatchUtils.simpleMatch(whitelist, request.getRequestURI());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = tokenUtil.extractToken(request, TokenType.ACCESS_TOKEN);
+
+        if (token == null) {
+            log.error("Access token is missing");
+            throw new GeneralHandler(ErrorStatus.MISSING_ACCESS_TOKEN);
+        }
+
+        // jwt 검증 로직
+//        DecodedJWT decodedJWT = tokenUtil.decodedJWT(token);
+//        Long id = decodedJWT.getClaim("id").asLong();
+//        Authentication authentication = new UsernamePasswordAuthenticationToken(id,null);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(1L,null);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        doFilter(request, response, filterChain);
+    }
+}

--- a/src/main/java/com/pitchain/jwt/TokenUtil.java
+++ b/src/main/java/com/pitchain/jwt/TokenUtil.java
@@ -1,0 +1,103 @@
+package com.pitchain.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.TokenType;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.redis.RedisTokenUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@Getter
+@Component
+@RequiredArgsConstructor
+public class TokenUtil {
+    @Value("${jwt.secret}")
+    private String secretKey;
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String BEARER = "Bearer ";
+
+    private final RedisTokenUtil redisTokenUtil;
+
+    public String issueAccessToken(Long memberId) {
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withClaim("id", memberId)
+                .withExpiresAt(new Date(System.currentTimeMillis() + accessTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public String issueRefreshToken(Long memberId) {
+        String refreshToken = JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withClaim("id", memberId)
+                .withExpiresAt(new Date(System.currentTimeMillis() + accessTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+        saveRefreshToken(memberId, refreshToken);
+        return refreshToken;
+    }
+
+    private void saveRefreshToken(Long memberId, String refreshToken) {
+        redisTokenUtil.setRefreshTokenWithExpire(refreshToken, memberId, Duration.ofDays(refreshTokenExpirationPeriod));
+    }
+
+    public String reissueAccessToken(String refreshToken) {
+        DecodedJWT decodedJWT;
+        try {
+            decodedJWT = JWT.require(Algorithm.HMAC512(secretKey)).build().verify(refreshToken);
+        } catch (JWTVerificationException e) {
+            throw new JWTVerificationException(e.getMessage());
+        }
+
+        Long memberId = decodedJWT.getClaim("id").asLong();
+
+        return issueAccessToken(memberId);
+    }
+
+    public String extractToken(HttpServletRequest request, TokenType tokenType) {
+        Optional<String> requestToken = switch (tokenType) {
+            case ACCESS_TOKEN -> Optional.ofNullable(request.getHeader(accessHeader))
+                    .filter(token -> token.startsWith(BEARER))
+                    .map(token -> token.substring(7));
+            case REFRESH_TOKEN -> Optional.ofNullable(request.getHeader(refreshHeader))
+                    .filter(token -> token.startsWith(BEARER))
+                    .map(token -> token.substring(7));
+            default -> throw new IllegalStateException("Unexpected value: " + tokenType);
+        };
+
+        return requestToken.orElse(null);
+    }
+
+    public DecodedJWT decodedJWT(String accessToken) {
+        try {
+            return JWT.require(Algorithm.HMAC512(secretKey)).build().verify(accessToken);
+        } catch (TokenExpiredException e) {
+            log.debug("AccessToken is expired: ${}", accessToken);
+            throw new GeneralHandler(ErrorStatus._UNAUTHORIZED);
+        }
+    }
+
+}

--- a/src/main/java/com/pitchain/redis/RedisTokenUtil.java
+++ b/src/main/java/com/pitchain/redis/RedisTokenUtil.java
@@ -1,0 +1,30 @@
+package com.pitchain.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Component
+public class RedisTokenUtil {
+    private final RedisTemplate<String, Long> refreshTokenTemplate;
+
+    public void setRefreshToken(String key, Long value) {
+        ValueOperations<String, Long> valueOperations = refreshTokenTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public void setRefreshTokenWithExpire(String key, Long value, Duration duration) {
+        ValueOperations<String, Long> valueOperations = refreshTokenTemplate.opsForValue();
+        valueOperations.set(key, value, duration);
+    }
+
+    public Long getMemberId(String key) {
+        ValueOperations<String, Long> valueOperations = refreshTokenTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+}


### PR DESCRIPTION
## ⭐ Summary

> #18 

<br>

## 📌 Tasks

1. exception 디렉토리를 common/exception으로 수정 (저번 pr에서 잘못 넣어놔서 이번에 같이 수정해버렸습니다..)
2. jwt 검증 필터 JwtAuthenticationFilter 구현
3. Refresh Token 저장하기 위한 RedisTokenUtil 구현
4. jwt 검증 도입으로 인한 SpringSecurityConfig, SwaggerConfig 수정
5. CORS 설정

<br>

## ETC

### 1. JWT 검증 및 memberId 반환
JWT 검증 로직 넣어두긴 했지만 저번 회의 때에서 언급했듯이 프로토타입에서는 사용자 정보를 고정해두고 사용하기 위해 우선 1L을 반환하게 설정
``` java
Authentication authentication = new UsernamePasswordAuthenticationToken(1L,null);
SecurityContextHolder.getContext().setAuthentication(authentication);
```