### PR TITLE
[fix]: CI 실패 해결

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, closed]
     branches: [dev]
     paths:


### PR DESCRIPTION
## ⭐ Summary

> #32 

<br>

## 📌 Tasks

1. CI 워크플로우 실행 트리거를 pull_request_target -> pull_request로 수정

<br>

## ETC
redis 문제라고 생각했지만 pull_request_target을 통해 pr base인 dev를 기준으로 빌드를 했고, 이전에 에러가 발생하고 있는 pr이 dev로 머지 되면서 에러를 발생하는 dev가 계속 빌드되고 있던 걸로 판단
