### PR TITLE
[fix] sp id 타입 변경 & CI 실패 해결

### DIFF
--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -24,10 +24,11 @@ public class SpController {
         return CustomApiResponse.onSuccess(spResList);
     }
 
-    @GetMapping("/{bmId}")
+    @GetMapping("/{spId}")
     public CustomApiResponse<SpRes> getSp(@AuthenticationPrincipal Long memberId,
-                                          @PathVariable Long bmId) {
-        SpRes spRes = spService.getSp(bmId);
+                                          @PathVariable Long spId) {
+        SpRes spRes = spService.getSp(spId);
         return CustomApiResponse.onSuccess(spRes);
     }
+
 }

--- a/src/main/java/com/pitchain/entity/Sp.java
+++ b/src/main/java/com/pitchain/entity/Sp.java
@@ -12,6 +12,10 @@ import lombok.NoArgsConstructor;
 public class Sp extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sp_id")
+    private Long id;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bm_id", nullable = false)
     private Bm bm;

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -24,8 +24,8 @@ public class SpService {
     }
 
     @Transactional(readOnly = true)
-    public SpRes getSp(Long bmId) {
-        Sp sp = spRepository.findById(bmId).orElseThrow(
+    public SpRes getSp(Long spId) {
+        Sp sp = spRepository.findById(spId).orElseThrow(
                 () -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND)
         );
 


### PR DESCRIPTION
## ⭐ Summary
> #29 #32

<br>

## 📌 Tasks
- SP id 타입을 BM -> Long으로 대체키를 통해 관리되도록 변경
- 작업을 forked repo -> organization repo로 관리

### ETC
이전 PR은 fork해서 작업하던 repo/fix/sp-#29에서 pr을 요청했다. 하지만 GitHub Secrets가 forked repo에서는 정상적으로 제공해주지 않기 때문에 yml이 생성되지 않았고 이를 해결하기 위해 Young-Flow에 직접 브랜치를 올리고 재pr 올렸습니다