### PR TITLE
[refactor] 댓글 API 삭제 로직 구체화 및 수정사항(1/2) 반영

### DIFF
--- a/src/main/java/com/pitchain/dto/res/CommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/CommentRes.java
@@ -11,8 +11,9 @@ public record CommentRes(
         Long commentId,
         Long writerId,
         String writerName,
+        String writerProfileImg,
         String content,
-        boolean deleted,
+        boolean delYN,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<ReplyCommentRes> replyComments
@@ -22,9 +23,10 @@ public record CommentRes(
                 .commentId(comment.getId())
                 .writerId(comment.getMember().getId())
                 .writerName(comment.getMember().getName())
+                .writerProfileImg(comment.getMember().getProfileImg())
                 .replyComments(comment.getChildComments().stream().map(ReplyCommentRes::createRes).toList())
                 .content(comment.getContent())
-                .deleted(comment.isDelYN())
+                .delYN(comment.isDelYN())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .build();

--- a/src/main/java/com/pitchain/dto/res/DeletedCommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/DeletedCommentRes.java
@@ -1,0 +1,21 @@
+package com.pitchain.dto.res;
+
+import com.pitchain.entity.Comment;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record DeletedCommentRes(
+        Long commentId,
+        boolean delYN,
+        List<ReplyCommentRes> replyComments
+) {
+    public static DeletedCommentRes createRes(Comment comment) {
+        return DeletedCommentRes.builder()
+                .commentId(comment.getId())
+                .delYN(comment.isDelYN())
+                .replyComments(comment.getChildComments().stream().map(ReplyCommentRes::createRes).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
@@ -10,6 +10,7 @@ public record ReplyCommentRes(
         Long commentId,
         Long writerId,
         String writerName,
+        String writerProfileImg,
         String content,
         boolean deleted,
         LocalDateTime createdAt,
@@ -20,6 +21,7 @@ public record ReplyCommentRes(
                 .commentId(comment.getId())
                 .writerId(comment.getMember().getId())
                 .writerName(comment.getMember().getName())
+                .writerProfileImg(comment.getMember().getProfileImg())
                 .content(comment.getContent())
                 .deleted(comment.isDelYN())
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
@@ -12,7 +12,7 @@ public record ReplyCommentRes(
         String writerName,
         String writerProfileImg,
         String content,
-        boolean deleted,
+        boolean delYN,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -23,7 +23,7 @@ public record ReplyCommentRes(
                 .writerName(comment.getMember().getName())
                 .writerProfileImg(comment.getMember().getProfileImg())
                 .content(comment.getContent())
-                .deleted(comment.isDelYN())
+                .delYN(comment.isDelYN())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .build();

--- a/src/main/java/com/pitchain/entity/Comment.java
+++ b/src/main/java/com/pitchain/entity/Comment.java
@@ -49,7 +49,7 @@ public class Comment extends BaseEntity {
         this.content = content;
     }
 
-    public void deleteComment() {
+    public void deleteParentComment() {
         this.delYN = true;
     }
 

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -30,6 +30,8 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Country country;
 
+    private String profileImg;
+
     @OneToMany(mappedBy = "member")
     private List<Investment> investments = new ArrayList<>();
 

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -4,6 +4,7 @@ import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.dto.CommentDto;
 import com.pitchain.dto.res.CommentRes;
+import com.pitchain.dto.res.DeletedCommentRes;
 import com.pitchain.entity.Bm;
 import com.pitchain.entity.Comment;
 import com.pitchain.entity.Member;
@@ -66,12 +67,18 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentRes> getComments(Long bmId) {
+    public List getComments(Long bmId) {
         Bm bm = bmRepository.findById(bmId).orElseThrow(() ->
                 new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
         List<Comment> comments = commentRepository.findByBm(bm);
-        return comments.stream().map(CommentRes::createRes).toList();
+
+        return comments.stream().map(comment -> {
+                    if (comment.isDelYN()) {
+                        return DeletedCommentRes.createRes(comment);
+                    }
+                    return CommentRes.createRes(comment);
+                }).toList();
     }
 
     @Transactional
@@ -98,7 +105,16 @@ public class CommentService {
         Member commentWriter = comment.getMember();
         checkAuthority(member, commentWriter);
 
-        comment.deleteComment();
+        if (isReplyComment(comment)) {
+            commentRepository.deleteById(commentId);
+        } else {
+            comment.deleteParentComment();
+        }
+    }
+
+    private boolean isReplyComment(Comment comment) {
+        List<Comment> childComments = comment.getChildComments();
+        return childComments.isEmpty();
     }
 
     private static void checkAuthority(Member member, Member commentWriter) {


### PR DESCRIPTION
## ⭐ Summary

> #43 

<br>

## 📌 Tasks

1. deleted -> delYN 변경
2. 댓글 삭제 -> delYN = true / 대댓글 삭제 -> 바로 삭제
3. 댓글 조회 시 유저 프로필 이미지 반환 추가하기

<br>

## 🖼️ Screenshot
댓글 조회 시 아래와 같이 응답
![응답-3](https://github.com/user-attachments/assets/145f91a2-a813-47d7-b505-8231ad5b79bf)
