### PR TITLE
[refactor] 1/5 회의 안건으로 인한 수정사항

### DIFF
--- a/src/main/java/com/pitchain/controller/BmController.java
+++ b/src/main/java/com/pitchain/controller/BmController.java
@@ -19,7 +19,7 @@ public class BmController {
     @GetMapping("{bmId}")
     public CustomApiResponse<BmDetailRes> getBmDetail(@AuthenticationPrincipal Long memberId,
                                                       @PathVariable("bmId") Long bmId) {
-        BmDetailRes bmDetailRes = bmService.getBmDetail(bmId);
+        BmDetailRes bmDetailRes = bmService.getBmDetail(memberId, bmId);
         return CustomApiResponse.onSuccess(bmDetailRes);
     }
 

--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -20,14 +20,14 @@ public class SpController {
 
     @GetMapping
     public CustomApiResponse<List<SpDetailRes>> getSpDetails(@AuthenticationPrincipal Long memberId) {
-        List<SpDetailRes> spDetailResList = spService.getSpDetails();
+        List<SpDetailRes> spDetailResList = spService.getSpDetails(memberId);
         return CustomApiResponse.onSuccess(spDetailResList);
     }
 
     @GetMapping("/{spId}")
     public CustomApiResponse<SpDetailRes> getSpDetail(@AuthenticationPrincipal Long memberId,
-                                                @PathVariable Long spId) {
-        SpDetailRes spDetailRes = spService.getSpDetail(spId);
+                                                      @PathVariable Long spId) {
+        SpDetailRes spDetailRes = spService.getSpDetail(memberId, spId);
         return CustomApiResponse.onSuccess(spDetailRes);
     }
 

--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -1,7 +1,7 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
-import com.pitchain.dto.res.SpRes;
+import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.service.SpService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,16 +19,16 @@ public class SpController {
     private final SpService spService;
 
     @GetMapping
-    public CustomApiResponse<List<SpRes>> getSps(@AuthenticationPrincipal Long memberId) {
-        List<SpRes> spResList = spService.getSps();
-        return CustomApiResponse.onSuccess(spResList);
+    public CustomApiResponse<List<SpDetailRes>> getSpDetails(@AuthenticationPrincipal Long memberId) {
+        List<SpDetailRes> spDetailResList = spService.getSpDetails();
+        return CustomApiResponse.onSuccess(spDetailResList);
     }
 
     @GetMapping("/{spId}")
-    public CustomApiResponse<SpRes> getSp(@AuthenticationPrincipal Long memberId,
-                                          @PathVariable Long spId) {
-        SpRes spRes = spService.getSp(spId);
-        return CustomApiResponse.onSuccess(spRes);
+    public CustomApiResponse<SpDetailRes> getSpDetail(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long spId) {
+        SpDetailRes spDetailRes = spService.getSpDetail(spId);
+        return CustomApiResponse.onSuccess(spDetailRes);
     }
 
 }

--- a/src/main/java/com/pitchain/dto/BmWithLikeDto.java
+++ b/src/main/java/com/pitchain/dto/BmWithLikeDto.java
@@ -1,0 +1,13 @@
+package com.pitchain.dto;
+
+import com.pitchain.entity.Bm;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BmWithLikeDto {
+    Bm bm;
+    boolean isLiked;
+    Long likeCnt;
+}

--- a/src/main/java/com/pitchain/dto/SpWithLikeDto.java
+++ b/src/main/java/com/pitchain/dto/SpWithLikeDto.java
@@ -1,0 +1,13 @@
+package com.pitchain.dto;
+
+import com.pitchain.entity.Sp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpWithLikeDto {
+    Sp sp;
+    boolean isLiked;
+    Long likeCnt;
+}

--- a/src/main/java/com/pitchain/dto/res/BmDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/BmDetailRes.java
@@ -21,7 +21,7 @@ public record BmDetailRes(
         Long valuationCap,
         LocalDate deadline,
         LocalDateTime createdAt,
-        Integer investmentGoal,
+        Integer goalInvestment,
         String longPitchUrl,
         String spURL,
         boolean isLiked // todo MyBm 개발 완료 후 추가 예정
@@ -41,7 +41,7 @@ public record BmDetailRes(
                 .valuationCap(bm.getValuationCap())
                 .deadline(bm.getDeadline())
                 .createdAt(bm.getCreatedAt())
-                .investmentGoal(bm.getInvestmentGoal())
+                .goalInvestment(bm.getGoalInvestment())
                 .longPitchUrl(bm.getLongPitchUrl())
                 .spURL(bm.getSp().getShortPitchURL())
                 .build();

--- a/src/main/java/com/pitchain/dto/res/BmDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/BmDetailRes.java
@@ -18,10 +18,7 @@ public record BmDetailRes(
         String description,
         String descriptionImg,
         String address,
-        Long valuationCap,
-        LocalDate deadline,
         LocalDateTime createdAt,
-        Integer goalInvestment,
         String longPitchUrl,
         String spURL,
         boolean isLiked // todo MyBm 개발 완료 후 추가 예정

--- a/src/main/java/com/pitchain/dto/res/BmDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/BmDetailRes.java
@@ -1,10 +1,11 @@
 package com.pitchain.dto.res;
 
+import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.entity.Bm;
 import lombok.Builder;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record BmDetailRes(
@@ -21,9 +22,12 @@ public record BmDetailRes(
         LocalDateTime createdAt,
         String longPitchUrl,
         String spURL,
-        boolean isLiked // todo MyBm 개발 완료 후 추가 예정
+        boolean isLiked,
+        Long likeCnt,
+        List<PtImgRes> ptImgResList
 ) {
-    public static BmDetailRes createRes(Bm bm) {
+    public static BmDetailRes createRes(BmWithLikeDto bmWithLikeDto, List<PtImgRes> ptImgResList) {
+        Bm bm = bmWithLikeDto.getBm();
         return BmDetailRes.builder()
                 .id(bm.getId())
                 .name(bm.getName())
@@ -35,12 +39,12 @@ public record BmDetailRes(
                 .description(bm.getDescription())
                 .descriptionImg(bm.getDescriptionImg())
                 .address(bm.getAddress())
-                .valuationCap(bm.getValuationCap())
-                .deadline(bm.getDeadline())
                 .createdAt(bm.getCreatedAt())
-                .goalInvestment(bm.getGoalInvestment())
                 .longPitchUrl(bm.getLongPitchUrl())
                 .spURL(bm.getSp().getShortPitchURL())
+                .isLiked(bmWithLikeDto.isLiked())
+                .likeCnt(bmWithLikeDto.getLikeCnt())
+                .ptImgResList(ptImgResList)
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/dto/res/InvestmentStatusRes.java
+++ b/src/main/java/com/pitchain/dto/res/InvestmentStatusRes.java
@@ -1,7 +1,10 @@
 package com.pitchain.dto.res;
 
 import com.pitchain.dto.InvestmentStatusDto;
+import com.pitchain.entity.Bm;
 import lombok.Builder;
+
+import java.time.LocalDate;
 
 @Builder
 public record InvestmentStatusRes(
@@ -9,15 +12,26 @@ public record InvestmentStatusRes(
         int achievementRate,
         long investorNum,
         long minimumAmount,
-        long maximumAmount
+        long maximumAmount,
+
+        Long valuationCap,
+        double pricePerShare,
+        Integer maxIssuedShare,
+        Long goalInvestment,
+        LocalDate deadline
 ) {
-    public static InvestmentStatusRes createRes(InvestmentStatusDto investmentStatusDto, int achievementRate) {
+    public static InvestmentStatusRes createRes(Bm bm, InvestmentStatusDto investmentStatusDto, int achievementRate) {
         return InvestmentStatusRes.builder()
                 .raisedAmount(investmentStatusDto.getRaisedAmount())
                 .achievementRate(achievementRate)
                 .investorNum(investmentStatusDto.getInvestorNum())
                 .minimumAmount(investmentStatusDto.getMinimumAmount())
                 .maximumAmount(investmentStatusDto.getMaximumAmount())
+                .valuationCap(bm.getValuationCap())
+                .pricePerShare(bm.getPricePerShare())
+                .maxIssuedShare(bm.getMaxIssuedShare())
+                .goalInvestment(bm.getGoalInvestment().longValue())
+                .deadline(bm.getDeadline())
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/dto/res/PtImgRes.java
+++ b/src/main/java/com/pitchain/dto/res/PtImgRes.java
@@ -1,0 +1,12 @@
+package com.pitchain.dto.res;
+
+import com.pitchain.entity.PtImg;
+
+public record PtImgRes(
+        int serialNum,
+        String img
+) {
+    public static PtImgRes createRes(PtImg ptImg) {
+        return new PtImgRes(ptImg.getSerialNum(), ptImg.getImg());
+    }
+}

--- a/src/main/java/com/pitchain/dto/res/SpDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/SpDetailRes.java
@@ -5,7 +5,7 @@ import com.pitchain.entity.Sp;
 import lombok.Builder;
 
 @Builder
-public record SpRes(
+public record SpDetailRes(
         Long bmId,
         String shortPitchURL,
         String thumbnailImg,
@@ -15,9 +15,9 @@ public record SpRes(
         String subCategory,
         String company
 ) {
-    public static SpRes createRes(Sp sp) {
+    public static SpDetailRes createRes(Sp sp) {
         Bm bm = sp.getBm();
-        return SpRes.builder()
+        return SpDetailRes.builder()
                 .bmId(sp.getBm().getId())
                 .shortPitchURL(sp.getShortPitchURL())
                 .thumbnailImg(sp.getThumbnailImg())

--- a/src/main/java/com/pitchain/dto/res/SpDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/SpDetailRes.java
@@ -1,5 +1,6 @@
 package com.pitchain.dto.res;
 
+import com.pitchain.dto.SpWithLikeDto;
 import com.pitchain.entity.Bm;
 import com.pitchain.entity.Sp;
 import lombok.Builder;
@@ -11,11 +12,15 @@ public record SpDetailRes(
         String thumbnailImg,
         int views,
         String name,
+        String logoImg,
         String mainCategory,
         String subCategory,
-        String company
+        String company,
+        boolean isLiked,
+        Long likeCnt
 ) {
-    public static SpDetailRes createRes(Sp sp) {
+    public static SpDetailRes createRes(SpWithLikeDto spWithLikeDto) {
+        Sp sp = spWithLikeDto.getSp();
         Bm bm = sp.getBm();
         return SpDetailRes.builder()
                 .bmId(sp.getBm().getId())
@@ -23,9 +28,12 @@ public record SpDetailRes(
                 .thumbnailImg(sp.getThumbnailImg())
                 .views(sp.getViews())
                 .name(sp.getName())
+                .logoImg(bm.getLogoImg())
                 .mainCategory(bm.getMainCategory().getKoreanName())
                 .subCategory(bm.getSubCategory().getKoreanName())
                 .company(bm.getCompany())
+                .isLiked(spWithLikeDto.isLiked())
+                .likeCnt(spWithLikeDto.getLikeCnt())
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -39,7 +39,7 @@ public class Bm extends BaseEntity {
     private String descriptionImg;
     private String address;
     private Long valuationCap;
-    private Integer investmentGoal;
+    private Integer goalInvestment;
     private LocalDate deadline;
     private String longPitchUrl;
 

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -4,6 +4,7 @@ import com.pitchain.common.constant.MainCategory;
 import com.pitchain.common.constant.SubCategory;
 import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,8 +39,12 @@ public class Bm extends BaseEntity {
 
     private String descriptionImg;
     private String address;
+    @Positive
     private Long valuationCap;
+    @Positive
     private Integer goalInvestment;
+    @Positive
+    private Integer maxIssuedShare;
     private LocalDate deadline;
     private String longPitchUrl;
 
@@ -54,4 +59,8 @@ public class Bm extends BaseEntity {
 
     @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
+
+    public int getPricePerShare() {
+        return goalInvestment / maxIssuedShare;
+    }
 }

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -60,7 +60,7 @@ public class Bm extends BaseEntity {
     @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    public int getPricePerShare() {
-        return goalInvestment / maxIssuedShare;
+    public double getPricePerShare() {
+        return (double) valuationCap / maxIssuedShare;
     }
 }

--- a/src/main/java/com/pitchain/repository/BmRepository.java
+++ b/src/main/java/com/pitchain/repository/BmRepository.java
@@ -1,15 +1,23 @@
 package com.pitchain.repository;
 
+import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.entity.Bm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface BmRepository extends JpaRepository<Bm, Long> {
-    @Query("SELECT b FROM Bm b "
-            + "LEFT JOIN FETCH b.sp "
-            + "WHERE b.id = :bmId")
-    Optional<Bm> findByIdWithSp(@Param("bmId") Long bmId);
+    @Query("""
+                SELECT DISTINCT new com.pitchain.dto.BmWithLikeDto(
+                    b,
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
+                    COUNT(mb.id)
+                )
+                FROM Bm b
+                LEFT JOIN MyBm mb ON mb.bm.id = b.id AND mb.member.id = :memberId
+                JOIN FETCH b.ptImgs
+                WHERE b.id = :bmId
+            """)
+    Optional<BmWithLikeDto> getBmWithLikeDto(Long memberId, Long bmId);
 }

--- a/src/main/java/com/pitchain/repository/SpRepository.java
+++ b/src/main/java/com/pitchain/repository/SpRepository.java
@@ -1,16 +1,38 @@
 package com.pitchain.repository;
 
+import com.pitchain.dto.SpWithLikeDto;
 import com.pitchain.entity.Sp;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface SpRepository extends JpaRepository<Sp, Long> {
-    @EntityGraph(attributePaths = "bm")
-    List<Sp> findAll();
+    @Query("""
+                SELECT DISTINCT new com.pitchain.dto.SpWithLikeDto(
+                    s,
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
+                    COUNT(mb.id)
+                )
+                FROM Sp s
+                LEFT JOIN FETCH s.bm b
+                LEFT JOIN MyBm mb ON mb.bm.id = b.id AND mb.member.id = :memberId
+            """)
+    List<SpWithLikeDto> findAllWithLike(@Param("memberId") Long memberId);
 
-    @EntityGraph(attributePaths = "bm")
-    Optional<Sp> findById(Long spId);
+    @Query("""
+                SELECT DISTINCT new com.pitchain.dto.SpWithLikeDto(
+                    s,
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
+                    COUNT(mb.id)
+                )
+                FROM Sp s
+                LEFT JOIN FETCH s.bm b
+                LEFT JOIN MyBm mb ON mb.bm.id = b.id AND mb.member.id = :memberId
+                WHERE s.id = :spId
+            """)
+    Optional<SpWithLikeDto> findSpWithLike(@Param("memberId") Long memberId,
+                                           @Param("spId") Long spId);
 }

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -2,12 +2,15 @@ package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.dto.res.BmDetailRes;
-import com.pitchain.entity.Bm;
+import com.pitchain.dto.res.PtImgRes;
 import com.pitchain.repository.BmRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
@@ -16,11 +19,14 @@ public class BmService {
     private final BmRepository bmRepository;
 
     @Transactional(readOnly = true)
-    public BmDetailRes getBmDetail(Long bmId) {
-        Bm bm = bmRepository.findByIdWithSp(bmId).orElseThrow(
-                () -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND)
-        );
+    public BmDetailRes getBmDetail(Long memberId, Long bmId) {
+        BmWithLikeDto bmWithLikeDto = bmRepository.getBmWithLikeDto(memberId, bmId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
-        return BmDetailRes.createRes(bm);
+        List<PtImgRes> ptImgResList = bmWithLikeDto.getBm().getPtImgs().stream()
+                .map(PtImgRes::createRes)
+                .toList();
+
+        return BmDetailRes.createRes(bmWithLikeDto, ptImgResList);
     }
 }

--- a/src/main/java/com/pitchain/service/InvestmentService.java
+++ b/src/main/java/com/pitchain/service/InvestmentService.java
@@ -42,7 +42,7 @@ public class InvestmentService {
         Bm bm = bmRepository.findById(bmId).orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
         InvestmentStatusDto investmentStatusDto = investmentRepository.findInvestmentStatusByBm(bm);
-        int achievementRate = getAchievementRate(bm.getInvestmentGoal(), investmentStatusDto.getRaisedAmount());
+        int achievementRate = getAchievementRate(bm.getGoalInvestment(), investmentStatusDto.getRaisedAmount());
 
         return InvestmentStatusRes.createRes(investmentStatusDto, achievementRate);
     }

--- a/src/main/java/com/pitchain/service/InvestmentService.java
+++ b/src/main/java/com/pitchain/service/InvestmentService.java
@@ -39,12 +39,13 @@ public class InvestmentService {
 
     @Transactional(readOnly = true)
     public InvestmentStatusRes getInvestmentStatus(Long bmId) {
-        Bm bm = bmRepository.findById(bmId).orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
+        Bm bm = bmRepository.findById(bmId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
         InvestmentStatusDto investmentStatusDto = investmentRepository.findInvestmentStatusByBm(bm);
         int achievementRate = getAchievementRate(bm.getGoalInvestment(), investmentStatusDto.getRaisedAmount());
 
-        return InvestmentStatusRes.createRes(investmentStatusDto, achievementRate);
+        return InvestmentStatusRes.createRes(bm, investmentStatusDto, achievementRate);
     }
 
     private int getAchievementRate(int investmentGoal, long raisedAmount) {

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -2,7 +2,7 @@ package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.exception.GeneralHandler;
-import com.pitchain.dto.res.SpRes;
+import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.entity.Sp;
 import com.pitchain.repository.SpRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,17 +18,17 @@ public class SpService {
     private final SpRepository spRepository;
 
     @Transactional(readOnly = true)
-    public List<SpRes> getSps() {
+    public List<SpDetailRes> getSpDetails() {
         List<Sp> sps = spRepository.findAll();
-        return sps.stream().map(SpRes::createRes).toList();
+        return sps.stream().map(SpDetailRes::createRes).toList();
     }
 
     @Transactional(readOnly = true)
-    public SpRes getSp(Long spId) {
+    public SpDetailRes getSpDetail(Long spId) {
         Sp sp = spRepository.findById(spId).orElseThrow(
                 () -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND)
         );
 
-        return SpRes.createRes(sp);
+        return SpDetailRes.createRes(sp);
     }
 }

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -2,8 +2,8 @@ package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.dto.SpWithLikeDto;
 import com.pitchain.dto.res.SpDetailRes;
-import com.pitchain.entity.Sp;
 import com.pitchain.repository.SpRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,17 +18,16 @@ public class SpService {
     private final SpRepository spRepository;
 
     @Transactional(readOnly = true)
-    public List<SpDetailRes> getSpDetails() {
-        List<Sp> sps = spRepository.findAll();
-        return sps.stream().map(SpDetailRes::createRes).toList();
+    public List<SpDetailRes> getSpDetails(Long memberId) {
+        List<SpWithLikeDto> spWithLikeDtos = spRepository.findAllWithLike(memberId);
+        return spWithLikeDtos.stream().map(SpDetailRes::createRes).toList();
     }
 
     @Transactional(readOnly = true)
-    public SpDetailRes getSpDetail(Long spId) {
-        Sp sp = spRepository.findById(spId).orElseThrow(
-                () -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND)
-        );
+    public SpDetailRes getSpDetail(Long memberId, Long spId) {
+        SpWithLikeDto spWithLikeDto = spRepository.findSpWithLike(memberId, spId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND));
 
-        return SpDetailRes.createRes(sp);
+        return SpDetailRes.createRes(spWithLikeDto);
     }
 }


### PR DESCRIPTION
## ⭐ Summary

> #64 

<br>

## 📌 Tasks
1. sp 조회 -> sp detail 조회 이름 수정
2. sp 상세 조회 칼럼 추가
    - logoImg 추가
    - isLiked 추가
    - likeCnt 추가
3. bm 상세 조회 칼럼 추가
    - isLiked 추가
    - likeCnt 추가
    - List<ptImg> 추가
4. investmentGoal -> goalInvestment 변수명 수정
5. 투자 현황 조회 칼럼 수정
    - bm 상세조회에서 반환하던 bm의 투자 정보를 투자 현황 조회 api에서 반환하도록 수정
    - 주당 가격 추가
    - 최대 발행 주식 추가

<br>

## ETC
투자 현황에 경우 sp 조회, bm 조회 시 모두 활용되기 때문에 bm 상세 조회에서 제공하던 deadLine, valuationCap, goalInvestment를 투자 현황 조회 api에서 반환하도록 수정했습니다

생성 및 등록 api도 심지어 아직 데이터셋도 저장되어 있지 않아 테스트를 진행해볼 수가 없네요.. 얼른 둘 중 하나는 작업해야 할 것 같습니다