### PR TITLE
[feat] BM 생성 수정 API 개발 및 버그 수정

### DIFF
--- a/src/main/java/com/pitchain/common/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/pitchain/common/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package com.pitchain.common.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    protected MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/pitchain/controller/BmController.java
+++ b/src/main/java/com/pitchain/controller/BmController.java
@@ -1,20 +1,32 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.dto.req.CreateBmReq;
+import com.pitchain.dto.req.UpdateBmReq;
 import com.pitchain.dto.res.BmDetailRes;
 import com.pitchain.service.BmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/bms")
 @RestController
 public class BmController {
     private final BmService bmService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse createBm(@AuthenticationPrincipal Long memberId,
+                                      @RequestPart CreateBmReq createBmReq,
+                                      @RequestPart(required = false) MultipartFile logoImg,
+                                      @RequestPart(required = false) MultipartFile descriptionImg) {
+        bmService.createBm(memberId, createBmReq, logoImg, descriptionImg);
+        return CustomApiResponse.onSuccess();
+    }
 
     @GetMapping("{bmId}")
     public CustomApiResponse<BmDetailRes> getBmDetail(@AuthenticationPrincipal Long memberId,
@@ -23,4 +35,28 @@ public class BmController {
         return CustomApiResponse.onSuccess(bmDetailRes);
     }
 
+    @PutMapping(value = "{bmId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse<BmDetailRes> updateBm(@AuthenticationPrincipal Long memberId,
+                                                   @PathVariable("bmId") Long bmId,
+                                                   @RequestBody UpdateBmReq updateBmReq,
+                                                   @RequestPart(required = false) MultipartFile logoImg,
+                                                   @RequestPart(required = false) MultipartFile descriptionImg) {
+        bmService.updateBm(memberId, bmId, updateBmReq, logoImg, descriptionImg);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @PostMapping(value = "{bmId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse updatePtImgs(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long bmId,
+                                          @RequestPart(required = false) List<MultipartFile> ptImgs) {
+        bmService.updatePtImgs(memberId, bmId, ptImgs);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @DeleteMapping("{bmId}")
+    public CustomApiResponse deleteBm(@AuthenticationPrincipal Long memberId,
+                                      @PathVariable("bmId") Long bmId) {
+        bmService.deleteBm(memberId, bmId);
+        return CustomApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/pitchain/controller/BmController.java
+++ b/src/main/java/com/pitchain/controller/BmController.java
@@ -1,20 +1,32 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.dto.req.CreateBmReq;
+import com.pitchain.dto.req.UpdateBmReq;
 import com.pitchain.dto.res.BmDetailRes;
 import com.pitchain.service.BmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/bms")
 @RestController
 public class BmController {
     private final BmService bmService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse createBm(@AuthenticationPrincipal Long memberId,
+                                      @RequestPart CreateBmReq createBmReq,
+                                      @RequestPart(required = false) MultipartFile logoImg,
+                                      @RequestPart(required = false) MultipartFile descriptionImg) {
+        bmService.createBm(memberId, createBmReq, logoImg, descriptionImg);
+        return CustomApiResponse.onSuccess();
+    }
 
     @GetMapping("{bmId}")
     public CustomApiResponse<BmDetailRes> getBmDetail(@AuthenticationPrincipal Long memberId,
@@ -23,4 +35,28 @@ public class BmController {
         return CustomApiResponse.onSuccess(bmDetailRes);
     }
 
+    @PutMapping(value = "{bmId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse<BmDetailRes> updateBm(@AuthenticationPrincipal Long memberId,
+                                                   @PathVariable("bmId") Long bmId,
+                                                   @RequestPart UpdateBmReq updateBmReq,
+                                                   @RequestPart(required = false) MultipartFile logoImg,
+                                                   @RequestPart(required = false) MultipartFile descriptionImg) {
+        bmService.updateBm(memberId, bmId, updateBmReq, logoImg, descriptionImg);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @PostMapping(value = "{bmId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse updatePtImgs(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long bmId,
+                                          @RequestPart(required = false) List<MultipartFile> ptImgs) {
+        bmService.updatePtImgs(memberId, bmId, ptImgs);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @DeleteMapping("{bmId}")
+    public CustomApiResponse deleteBm(@AuthenticationPrincipal Long memberId,
+                                      @PathVariable("bmId") Long bmId) {
+        bmService.deleteBm(memberId, bmId);
+        return CustomApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/pitchain/controller/S3Controller.java
+++ b/src/main/java/com/pitchain/controller/S3Controller.java
@@ -2,7 +2,7 @@ package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
 import com.pitchain.common.constant.S3UploadTarget;
-import com.pitchain.service.S3Uploader;
+import com.pitchain.service.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -13,20 +13,20 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class S3Controller {
 
-    private final S3Uploader s3Uploader;
+    private final S3Service s3Service;
 
     @Operation(summary = "파일(이미지, 동영상) 저장 / 개발용")
     @PostMapping(value = "/s3", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CustomApiResponse<String> uploadFile(@RequestPart MultipartFile file,
                                                 @RequestParam S3UploadTarget s3UploadTarget) {
-        String fileURL = s3Uploader.uploadFile(file, s3UploadTarget);
+        String fileURL = s3Service.uploadFile(file, s3UploadTarget);
         return CustomApiResponse.onSuccess(fileURL);
     }
 
     @Operation(summary = "파일(이미지, 동영상) 삭제 / 개발용")
     @DeleteMapping("/s3")
     public CustomApiResponse deleteFile(@RequestParam String fileURL) {
-        s3Uploader.deleteFile(fileURL);
+        s3Service.deleteFile(fileURL);
         return CustomApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/pitchain/dto/BmWithLikeDto.java
+++ b/src/main/java/com/pitchain/dto/BmWithLikeDto.java
@@ -9,5 +9,4 @@ import lombok.Getter;
 public class BmWithLikeDto {
     Bm bm;
     boolean isLiked;
-    Long likeCnt;
 }

--- a/src/main/java/com/pitchain/dto/req/CreateBmReq.java
+++ b/src/main/java/com/pitchain/dto/req/CreateBmReq.java
@@ -1,0 +1,43 @@
+package com.pitchain.dto.req;
+
+import com.pitchain.common.constant.MainCategory;
+import com.pitchain.common.constant.SubCategory;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+
+import java.time.LocalDate;
+
+public record CreateBmReq(
+        String name,
+        MainCategory mainCategory,
+        SubCategory subCategory,
+        String company,
+        String intro,
+        String description,
+        String address,
+        Long valuationCap,
+        Integer goalInvestment,
+        Integer maxIssuedShare,
+        LocalDate deadline,
+        String longPitchUrl
+) {
+    public Bm createBm(Member member, String logoImg, String descriptionImg) {
+        return Bm.builder()
+                .member(member)
+                .name(name)
+                .mainCategory(mainCategory)
+                .subCategory(subCategory)
+                .company(company)
+                .logoImg(logoImg)
+                .intro(intro)
+                .description(description)
+                .descriptionImg(descriptionImg)
+                .address(address)
+                .valuationCap(valuationCap)
+                .goalInvestment(goalInvestment)
+                .maxIssuedShare(maxIssuedShare)
+                .deadline(deadline)
+                .longPitchUrl(longPitchUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/dto/req/UpdateBmReq.java
+++ b/src/main/java/com/pitchain/dto/req/UpdateBmReq.java
@@ -1,0 +1,41 @@
+package com.pitchain.dto.req;
+
+import com.pitchain.common.constant.MainCategory;
+import com.pitchain.common.constant.SubCategory;
+import com.pitchain.entity.Bm;
+
+import java.time.LocalDate;
+
+public record UpdateBmReq(
+        String name,
+        MainCategory mainCategory,
+        SubCategory subCategory,
+        String company,
+        String intro,
+        String description,
+        String address,
+        Long valuationCap,
+        Integer goalInvestment,
+        Integer maxIssuedShare,
+        LocalDate deadline,
+        String longPitchUrl
+) {
+    public Bm createBm(String logoImg, String descriptionImg) {
+        return Bm.builder()
+                .name(name)
+                .mainCategory(mainCategory)
+                .subCategory(subCategory)
+                .company(company)
+                .logoImg(logoImg)
+                .intro(intro)
+                .description(description)
+                .descriptionImg(descriptionImg)
+                .address(address)
+                .valuationCap(valuationCap)
+                .goalInvestment(goalInvestment)
+                .maxIssuedShare(maxIssuedShare)
+                .deadline(deadline)
+                .longPitchUrl(longPitchUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/dto/res/BmDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/BmDetailRes.java
@@ -23,10 +23,10 @@ public record BmDetailRes(
         String longPitchUrl,
         String spURL,
         boolean isLiked,
-        Long likeCnt,
+        long likeCnt,
         List<PtImgRes> ptImgResList
 ) {
-    public static BmDetailRes createRes(BmWithLikeDto bmWithLikeDto, List<PtImgRes> ptImgResList) {
+    public static BmDetailRes createRes(BmWithLikeDto bmWithLikeDto, long likeCnt, List<PtImgRes> ptImgResList) {
         Bm bm = bmWithLikeDto.getBm();
         return BmDetailRes.builder()
                 .id(bm.getId())
@@ -41,9 +41,9 @@ public record BmDetailRes(
                 .address(bm.getAddress())
                 .createdAt(bm.getCreatedAt())
                 .longPitchUrl(bm.getLongPitchUrl())
-                .spURL(bm.getSp().getShortPitchURL())
+                .spURL(bm.getShortPitchURL())
                 .isLiked(bmWithLikeDto.isLiked())
-                .likeCnt(bmWithLikeDto.getLikeCnt())
+                .likeCnt(likeCnt)
                 .ptImgResList(ptImgResList)
                 .build();
     }

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -69,4 +69,57 @@ public class Bm extends BaseEntity {
     public double getPricePerShare() {
         return (double) valuationCap / maxIssuedShare;
     }
+
+    @Builder
+    public Bm(Member member, String name, MainCategory mainCategory, SubCategory subCategory,
+              String company, String logoImg, String intro, String description, String descriptionImg,
+              String address, Long valuationCap, Integer goalInvestment, Integer maxIssuedShare,
+              LocalDate deadline, String longPitchUrl) {
+        this.member = member;
+        this.name = name;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
+        this.company = company;
+        this.logoImg = logoImg;
+        this.intro = intro;
+        this.description = description;
+        this.descriptionImg = descriptionImg;
+        this.address = address;
+        this.valuationCap = valuationCap;
+        this.goalInvestment = goalInvestment;
+        this.maxIssuedShare = maxIssuedShare;
+        this.deadline = deadline;
+        this.longPitchUrl = longPitchUrl;
+    }
+
+    public String getShortPitchURL() {
+        if (sp == null)
+            return Strings.EMPTY;
+        return sp.getShortPitchURL();
+    }
+
+    public boolean isOwner(Long memberId) {
+        return memberId.equals(member.getId());
+    }
+
+    public void updatePtImgs(List<PtImg> ptImgs) {
+        this.ptImgs = ptImgs;
+    }
+
+    public void update(Bm updateBm) {
+        this.name = updateBm.getName();
+        this.mainCategory = updateBm.getMainCategory();
+        this.subCategory = updateBm.getSubCategory();
+        this.company = updateBm.getCompany();
+        this.logoImg = updateBm.getLogoImg();
+        this.intro = updateBm.getIntro();
+        this.description = updateBm.getDescription();
+        this.descriptionImg = updateBm.getDescriptionImg();
+        this.address = updateBm.getAddress();
+        this.valuationCap = updateBm.getValuationCap();
+        this.goalInvestment = updateBm.getGoalInvestment();
+        this.maxIssuedShare = updateBm.getMaxIssuedShare();
+        this.deadline = updateBm.getDeadline();
+        this.longPitchUrl = updateBm.getLongPitchUrl();
+    }
 }

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -103,7 +103,11 @@ public class Bm extends BaseEntity {
     }
 
     public void updatePtImgs(List<PtImg> ptImgs) {
-        this.ptImgs = ptImgs;
+        if (ptImgs == null)
+            ptImgs = new ArrayList<>();
+
+        this.ptImgs.clear();
+        this.ptImgs.addAll(ptImgs);
     }
 
     public void update(Bm updateBm) {

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -6,8 +6,10 @@ import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -48,13 +50,17 @@ public class Bm extends BaseEntity {
     private LocalDate deadline;
     private String longPitchUrl;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY)
     private List<Investment> investments = new ArrayList<>();
 
     @OneToOne(mappedBy = "bm", fetch = FetchType.LAZY)
     private Sp sp;
 
-    @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PtImg> ptImgs = new ArrayList<>();
 
     @OneToMany(mappedBy = "bm", fetch = FetchType.LAZY)

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -43,4 +43,11 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member")
     private List<Comment> comments = new ArrayList<>();
+
+    public Member(String name, String email, Country country, String profileImg) {
+        this.name = name;
+        this.email = email;
+        this.country = country;
+        this.profileImg = profileImg;
+    }
 }

--- a/src/main/java/com/pitchain/entity/PtImg.java
+++ b/src/main/java/com/pitchain/entity/PtImg.java
@@ -24,4 +24,9 @@ public class PtImg {
     @Column(nullable = false)
     private String img;
 
+    public PtImg(Bm bm, int serialNum, String img) {
+        this.bm = bm;
+        this.serialNum = serialNum;
+        this.img = img;
+    }
 }

--- a/src/main/java/com/pitchain/repository/BmRepository.java
+++ b/src/main/java/com/pitchain/repository/BmRepository.java
@@ -2,22 +2,30 @@ package com.pitchain.repository;
 
 import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.entity.Bm;
+import com.pitchain.entity.PtImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BmRepository extends JpaRepository<Bm, Long> {
     @Query("""
                 SELECT DISTINCT new com.pitchain.dto.BmWithLikeDto(
                     b,
-                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
-                    COUNT(mb.id)
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END
                 )
                 FROM Bm b
                 LEFT JOIN MyBm mb ON mb.bm.id = b.id AND mb.member.id = :memberId
-                JOIN FETCH b.ptImgs
                 WHERE b.id = :bmId
+                GROUP BY b, mb.member.id
             """)
     Optional<BmWithLikeDto> getBmWithLikeDto(Long memberId, Long bmId);
+
+    @Query("""
+        SELECT pi
+        FROM PtImg pi
+        WHERE pi.bm.id = :bmId
+    """)
+    List<PtImg> getPtImgsByBmId(Long bmId);
 }

--- a/src/main/java/com/pitchain/repository/BmRepository.java
+++ b/src/main/java/com/pitchain/repository/BmRepository.java
@@ -3,6 +3,7 @@ package com.pitchain.repository;
 import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.entity.Bm;
 import com.pitchain.entity.PtImg;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,9 +24,17 @@ public interface BmRepository extends JpaRepository<Bm, Long> {
     Optional<BmWithLikeDto> getBmWithLikeDto(Long memberId, Long bmId);
 
     @Query("""
-        SELECT pi
-        FROM PtImg pi
-        WHERE pi.bm.id = :bmId
-    """)
+                SELECT pi
+                FROM PtImg pi
+                WHERE pi.bm.id = :bmId
+            """)
     List<PtImg> getPtImgsByBmId(Long bmId);
+
+    @Query("""
+                SELECT b 
+                FROM Bm b
+                LEFT JOIN FETCH b.ptImgs
+                WHERE b.id = :bmId
+            """)
+    Optional<Bm> getByIdWithPtImgs(Long bmId);
 }

--- a/src/main/java/com/pitchain/repository/EntityFacade.java
+++ b/src/main/java/com/pitchain/repository/EntityFacade.java
@@ -1,0 +1,32 @@
+package com.pitchain.repository;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.Sp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EntityFacade {
+    private final MemberRepository memberRepository;
+    private final BmRepository bmRepository;
+    private final SpRepository spRepository;
+
+    public Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Bm getBm(Long bmId) {
+        return bmRepository.findById(bmId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
+    }
+
+    public Sp getSp(Long spId) {
+        return spRepository.findById(spId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/pitchain/repository/MyBmRepository.java
+++ b/src/main/java/com/pitchain/repository/MyBmRepository.java
@@ -6,6 +6,7 @@ import com.pitchain.entity.MyBm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MyBmRepository extends JpaRepository<MyBm, Long> {
+    long countByBm(Bm bm);
 
     boolean existsByMemberAndBm(Member member, Bm bm);
 

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -1,10 +1,14 @@
 package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.S3UploadTarget;
 import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.dto.BmWithLikeDto;
+import com.pitchain.dto.req.CreateBmReq;
+import com.pitchain.dto.req.UpdateBmReq;
 import com.pitchain.dto.res.BmDetailRes;
 import com.pitchain.dto.res.PtImgRes;
+import com.pitchain.entity.Bm;
 import com.pitchain.entity.Member;
 import com.pitchain.entity.PtImg;
 import com.pitchain.repository.BmRepository;
@@ -13,7 +17,9 @@ import com.pitchain.repository.MyBmRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -23,6 +29,16 @@ public class BmService {
     private final EntityFacade entityFacade;
     private final BmRepository bmRepository;
     private final MyBmRepository myBmRepository;
+    private final S3Uploader s3Uploader;
+
+    public void createBm(Long memberId, CreateBmReq createBmReq, MultipartFile logoImg, MultipartFile descriptionImg) {
+        Member member = entityFacade.getMember(memberId);
+        String logoImgURL = s3Uploader.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descriptionImgURL = s3Uploader.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+
+        Bm newBm = createBmReq.createBm(member, logoImgURL, descriptionImgURL);
+        bmRepository.save(newBm);
+    }
 
     @Transactional(readOnly = true)
     public BmDetailRes getBmDetail(Long memberId, Long bmId) {
@@ -39,5 +55,49 @@ public class BmService {
         long likeCnt = myBmRepository.countByBm(bmWithLikeDto.getBm());
 
         return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList);
+    }
+
+    public void updateBm(Long memberId, Long bmId, UpdateBmReq updateBmReq, MultipartFile logoImg, MultipartFile descriptionImg) {
+        Member member = entityFacade.getMember(memberId);
+        Bm bm = entityFacade.getBm(bmId);
+
+        validateBmOwner(bm, member);
+
+        String logoImgURL = s3Uploader.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descriptionImgURL = s3Uploader.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+
+        Bm updateBm = updateBmReq.createBm(logoImgURL, descriptionImgURL);
+
+        bm.update(updateBm);
+    }
+
+    public void updatePtImgs(Long memberId, Long bmId, List<MultipartFile> ptImgs) {
+        Member member = entityFacade.getMember(memberId);
+        Bm bm = entityFacade.getBm(bmId);
+
+        validateBmOwner(bm, member);
+
+        List<PtImg> uploadPtImgs = new ArrayList<>();
+        for (int serialNum = 0; ptImgs != null && serialNum < ptImgs.size(); serialNum++) {
+            String uploadFileURL = s3Uploader.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
+            PtImg ptImg = new PtImg(bm, serialNum, uploadFileURL);
+            uploadPtImgs.add(ptImg);
+        }
+
+        bm.updatePtImgs(uploadPtImgs);
+    }
+
+    public void deleteBm(Long memberId, Long bmId) {
+        Member member = entityFacade.getMember(memberId);
+        Bm bm = entityFacade.getBm(bmId);
+
+        validateBmOwner(bm, member);
+
+        bmRepository.delete(bm);
+    }
+
+    private static void validateBmOwner(Bm bm, Member member) {
+        if (!bm.isOwner(member.getId()))
+            throw new GeneralHandler(ErrorStatus.MEMBER_FORBIDDEN);
     }
 }

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -29,12 +29,12 @@ public class BmService {
     private final EntityFacade entityFacade;
     private final BmRepository bmRepository;
     private final MyBmRepository myBmRepository;
-    private final S3Uploader s3Uploader;
+    private final S3Service s3Service;
 
     public void createBm(Long memberId, CreateBmReq createBmReq, MultipartFile logoImg, MultipartFile descriptionImg) {
         Member member = entityFacade.getMember(memberId);
-        String logoImgURL = s3Uploader.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
-        String descriptionImgURL = s3Uploader.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+        String logoImgURL = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descriptionImgURL = s3Service.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
 
         Bm newBm = createBmReq.createBm(member, logoImgURL, descriptionImgURL);
         bmRepository.save(newBm);
@@ -63,8 +63,8 @@ public class BmService {
 
         validateBmOwner(bm, member);
 
-        String logoImgURL = s3Uploader.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
-        String descriptionImgURL = s3Uploader.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+        String logoImgURL = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descriptionImgURL = s3Service.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
 
         Bm updateBm = updateBmReq.createBm(logoImgURL, descriptionImgURL);
 
@@ -79,7 +79,7 @@ public class BmService {
 
         List<PtImg> uploadPtImgs = new ArrayList<>();
         for (int serialNum = 0; ptImgs != null && serialNum < ptImgs.size(); serialNum++) {
-            String uploadFileURL = s3Uploader.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
+            String uploadFileURL = s3Service.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
             PtImg ptImg = new PtImg(bm, serialNum, uploadFileURL);
             uploadPtImgs.add(ptImg);
         }

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -71,20 +71,33 @@ public class BmService {
         bm.update(updateBm);
     }
 
-    public void updatePtImgs(Long memberId, Long bmId, List<MultipartFile> ptImgs) {
+    public void updatePtImgs(Long memberId, Long bmId, List<MultipartFile> uploadPtImgs) {
         Member member = entityFacade.getMember(memberId);
-        Bm bm = entityFacade.getBm(bmId);
+        Bm bm = bmRepository.getByIdWithPtImgs(bmId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
         validateBmOwner(bm, member);
 
+        deletePtImgs(bm);
+        List<PtImg> uploadedPtImgs = uploadPtImgs(uploadPtImgs, bm);
+
+        bm.updatePtImgs(uploadedPtImgs);
+    }
+
+    private void deletePtImgs(Bm bm) {
+        List<PtImg> ptImgs = bm.getPtImgs();
+        System.out.println("ptImgs = " + ptImgs);
+        ptImgs.forEach(pi -> s3Service.deleteFile(pi.getImg()));
+    }
+
+    private List<PtImg> uploadPtImgs(List<MultipartFile> ptImgs, Bm bm) {
         List<PtImg> uploadPtImgs = new ArrayList<>();
         for (int serialNum = 0; ptImgs != null && serialNum < ptImgs.size(); serialNum++) {
             String uploadFileURL = s3Service.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
             PtImg ptImg = new PtImg(bm, serialNum, uploadFileURL);
             uploadPtImgs.add(ptImg);
         }
-
-        bm.updatePtImgs(uploadPtImgs);
+        return uploadPtImgs;
     }
 
     public void deleteBm(Long memberId, Long bmId) {

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -5,7 +5,11 @@ import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.dto.res.BmDetailRes;
 import com.pitchain.dto.res.PtImgRes;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.PtImg;
 import com.pitchain.repository.BmRepository;
+import com.pitchain.repository.EntityFacade;
+import com.pitchain.repository.MyBmRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,17 +20,24 @@ import java.util.List;
 @Transactional
 @Service
 public class BmService {
+    private final EntityFacade entityFacade;
     private final BmRepository bmRepository;
+    private final MyBmRepository myBmRepository;
 
     @Transactional(readOnly = true)
     public BmDetailRes getBmDetail(Long memberId, Long bmId) {
-        BmWithLikeDto bmWithLikeDto = bmRepository.getBmWithLikeDto(memberId, bmId)
+        Member member = entityFacade.getMember(memberId);
+
+        BmWithLikeDto bmWithLikeDto = bmRepository.getBmWithLikeDto(member.getId(), bmId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
 
-        List<PtImgRes> ptImgResList = bmWithLikeDto.getBm().getPtImgs().stream()
+        List<PtImg> ptImgs = bmRepository.getPtImgsByBmId(bmWithLikeDto.getBm().getId());
+        List<PtImgRes> ptImgResList = ptImgs.stream()
                 .map(PtImgRes::createRes)
                 .toList();
 
-        return BmDetailRes.createRes(bmWithLikeDto, ptImgResList);
+        long likeCnt = myBmRepository.countByBm(bmWithLikeDto.getBm());
+
+        return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList);
     }
 }

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class S3Uploader {
+public class S3Service {
     private final S3Operations s3Operations;
 
     @Value("${spring.cloud.aws.s3.bucket.image}")

--- a/src/main/java/com/pitchain/service/S3Uploader.java
+++ b/src/main/java/com/pitchain/service/S3Uploader.java
@@ -33,6 +33,8 @@ public class S3Uploader {
 
     public String uploadFile(MultipartFile file, S3UploadTarget target) {
         String fileURL = Strings.EMPTY;
+        if (file == null || file.isEmpty())
+            return fileURL;
 
         try {
             validateMimeType(file, target);

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -294,18 +294,15 @@ class BmServiceTest {
     }
 
     @Test
-    void BM_PT_IMG_수정_성공() {
+    void BM_PT_IMG_추가_성공() {
         //given
         Member member = saveMember();
         Bm bm = saveBm(member);
 
         List<MultipartFile> ptImgs = List.of(
-                new MockMultipartFile(
-                        "img_1", "img_1.png", "image/png", "img1".getBytes()),
-                new MockMultipartFile(
-                        "img_2", "img_2.png", "image/png", "img2".getBytes()),
-                new MockMultipartFile(
-                        "img_3", "img_3.png", "image/png", "img3".getBytes())
+                new MockMultipartFile("img_1", "img_1.png", "image/png", "img1".getBytes()),
+                new MockMultipartFile("img_2", "img_2.png", "image/png", "img2".getBytes()),
+                new MockMultipartFile("img_3", "img_3.png", "image/png", "img3".getBytes())
         );
 
         for (int i = 0; i < ptImgs.size(); i++) {
@@ -323,6 +320,42 @@ class BmServiceTest {
 
         assertThat(updatedPtImgs).hasSize(ptImgs.size());
         for (int i = 0; i < ptImgs.size(); i++) {
+            assertThat(updatedPtImgs.get(i).getSerialNum()).isEqualTo(i);
+            assertThat(updatedPtImgs.get(i).getBm().getId()).isEqualTo(updatedBm.getId());
+            assertThat(updatedPtImgs.get(i).getImg()).isEqualTo("fake_" + (i + 1));
+        }
+    }
+
+    @Test
+    void BM_PT_IMG_수정_성공() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+        bm.updatePtImgs(List.of(
+                new PtImg(bm, 0, "origin_img_0.png"),
+                new PtImg(bm, 1, "origin_img_1.png")
+        ));
+
+        List<MultipartFile> updatePtImgs = List.of(
+                new MockMultipartFile("img_1", "img_1.png", "image/png", "img1".getBytes()),
+                new MockMultipartFile("img_2", "img_2.png", "image/png", "img2".getBytes()),
+                new MockMultipartFile("img_3", "img_3.png", "image/png", "img3".getBytes())
+        );
+        for (int i = 0; i < updatePtImgs.size(); i++) {
+            String fakeUrl = "fake_" + (i + 1);
+            when(s3Service.uploadFile(updatePtImgs.get(i), S3UploadTarget.COMPANY_PT))
+                    .thenReturn(fakeUrl);
+        }
+
+        //when
+        bmService.updatePtImgs(member.getId(), bm.getId(), updatePtImgs);
+
+        //then
+        Bm updatedBm = bmRepository.findById(bm.getId()).orElseThrow();
+        List<PtImg> updatedPtImgs = updatedBm.getPtImgs();
+
+        assertThat(updatedPtImgs).hasSize(updatePtImgs.size());
+        for (int i = 0; i < updatePtImgs.size(); i++) {
             assertThat(updatedPtImgs.get(i).getSerialNum()).isEqualTo(i);
             assertThat(updatedPtImgs.get(i).getBm().getId()).isEqualTo(updatedBm.getId());
             assertThat(updatedPtImgs.get(i).getImg()).isEqualTo("fake_" + (i + 1));

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 class BmServiceTest {
     @MockBean
-    private S3Uploader s3Uploader;
+    private S3Service s3Service;
     @Autowired
     private BmService bmService;
     @Autowired
@@ -91,9 +91,9 @@ class BmServiceTest {
         CreateBmReq createBmReq = new CreateBmReq(NAME, MAIN_CATEGORY, SUB_CATEGORY, COMPANY,
                 INTRO, DESCRIPTION, ADDRESS, VALUATION_CAP, GOAL_INVESTMENT, MAX_ISSUED_SHARE, DEADLINE, LONG_PITCH_URL);
 
-        when(s3Uploader.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
+        when(s3Service.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
                 .thenReturn(LOGO_IMG_URL);
-        when(s3Uploader.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
+        when(s3Service.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
                 .thenReturn(DESCRIPTION_IMG_URL);
 
         //when
@@ -228,9 +228,9 @@ class BmServiceTest {
                 updatedMaxIssuedShare, updatedDeadline, updatedLongPitchUrl
         );
 
-        when(s3Uploader.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
+        when(s3Service.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
                 .thenReturn(updatedLogoImgUrl);
-        when(s3Uploader.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
+        when(s3Service.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
                 .thenReturn(updatedDescriptionImgUrl);
 
         //when
@@ -310,7 +310,7 @@ class BmServiceTest {
 
         for (int i = 0; i < ptImgs.size(); i++) {
             String fakeUrl = "fake_" + (i + 1);
-            when(s3Uploader.uploadFile(ptImgs.get(i), S3UploadTarget.COMPANY_PT))
+            when(s3Service.uploadFile(ptImgs.get(i), S3UploadTarget.COMPANY_PT))
                     .thenReturn(fakeUrl);
         }
 

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -1,0 +1,386 @@
+package com.pitchain.service;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.Country;
+import com.pitchain.common.constant.MainCategory;
+import com.pitchain.common.constant.S3UploadTarget;
+import com.pitchain.common.constant.SubCategory;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.dto.req.CreateBmReq;
+import com.pitchain.dto.req.UpdateBmReq;
+import com.pitchain.dto.res.BmDetailRes;
+import com.pitchain.dto.res.PtImgRes;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.MyBm;
+import com.pitchain.entity.PtImg;
+import com.pitchain.repository.BmRepository;
+import com.pitchain.repository.MemberRepository;
+import com.pitchain.repository.MyBmRepository;
+import jakarta.transaction.Transactional;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@SpringBootTest
+class BmServiceTest {
+    @MockBean
+    private S3Uploader s3Uploader;
+    @Autowired
+    private BmService bmService;
+    @Autowired
+    private BmRepository bmRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MyBmRepository myBmRepository;
+
+    private static final String NAME = "bm_name";
+    private static final MainCategory MAIN_CATEGORY = MainCategory.FOOD;
+    private static final SubCategory SUB_CATEGORY = SubCategory.BEVERAGE_COFFEE;
+    private static final String COMPANY = "bm_company";
+    private static final String LOGO_IMG_URL = "bm_logo_img_url";
+    private static final String INTRO = "bm_intro";
+    private static final String DESCRIPTION = "bm_description";
+    private static final String DESCRIPTION_IMG_URL = "bm_description_img_url";
+    private static final String ADDRESS = "bm_address";
+    private static final Long VALUATION_CAP = 100000L;
+    private static final Integer GOAL_INVESTMENT = 1000;
+    private static final Integer MAX_ISSUED_SHARE = 1000;
+    private static final LocalDate DEADLINE = LocalDate.now();
+    private static final String LONG_PITCH_URL = "bm_longPitchUrl";
+
+    private static final MockMultipartFile LOGO_IMG = new MockMultipartFile(
+            "logo", "logo.png", "image/png", "test data 1".getBytes());
+    private static final MockMultipartFile DESCRIPTION_IMG = new MockMultipartFile(
+            "description", "description.png", "image/png", "test data 2".getBytes());
+
+    private Member saveMember() {
+        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+    }
+    private Bm saveBm(Member member) {
+        return bmRepository.save(new Bm(member, NAME, MAIN_CATEGORY, SUB_CATEGORY, COMPANY, LOGO_IMG_URL,
+                INTRO, DESCRIPTION, DESCRIPTION_IMG_URL, ADDRESS, VALUATION_CAP,
+                GOAL_INVESTMENT, MAX_ISSUED_SHARE, DEADLINE, LONG_PITCH_URL));
+    }
+    private List<PtImg> createPtImgs(Bm bm) {
+        return List.of(
+                new PtImg(bm, 1, "fake_01.jpg"),
+                new PtImg(bm, 2, "fake_02.jpg"),
+                new PtImg(bm, 3, "fake_03.jpg")
+        );
+    }
+
+    @Test
+    void BM_생성_성공() {
+        //given
+        Member member = saveMember();
+        CreateBmReq createBmReq = new CreateBmReq(NAME, MAIN_CATEGORY, SUB_CATEGORY, COMPANY,
+                INTRO, DESCRIPTION, ADDRESS, VALUATION_CAP, GOAL_INVESTMENT, MAX_ISSUED_SHARE, DEADLINE, LONG_PITCH_URL);
+
+        when(s3Uploader.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
+                .thenReturn(LOGO_IMG_URL);
+        when(s3Uploader.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
+                .thenReturn(DESCRIPTION_IMG_URL);
+
+        //when
+        bmService.createBm(member.getId(), createBmReq, LOGO_IMG, DESCRIPTION_IMG);
+
+        //then
+        List<Bm> all = bmRepository.findAll();
+        Bm bm = all.get(0);
+
+        assertThat(bm.getName()).isEqualTo(NAME);
+        assertThat(bm.getMainCategory()).isEqualTo(MAIN_CATEGORY);
+        assertThat(bm.getSubCategory()).isEqualTo(SUB_CATEGORY);
+        assertThat(bm.getCompany()).isEqualTo(COMPANY);
+        assertThat(bm.getLogoImg()).isEqualTo(LOGO_IMG_URL);
+        assertThat(bm.getIntro()).isEqualTo(INTRO);
+        assertThat(bm.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(bm.getDescriptionImg()).isEqualTo(DESCRIPTION_IMG_URL);
+        assertThat(bm.getAddress()).isEqualTo(ADDRESS);
+        assertThat(bm.getValuationCap()).isEqualTo(VALUATION_CAP);
+        assertThat(bm.getGoalInvestment()).isEqualTo(GOAL_INVESTMENT);
+        assertThat(bm.getMaxIssuedShare()).isEqualTo(MAX_ISSUED_SHARE);
+        assertThat(bm.getDeadline()).isEqualTo(DEADLINE);
+        assertThat(bm.getLongPitchUrl()).isEqualTo(LONG_PITCH_URL);
+    }
+
+    @Test
+    void BM_조회_성공_좋아요_없음() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+
+        List<PtImg> ptImgs = createPtImgs(bm);
+        bm.updatePtImgs(ptImgs);
+        List<PtImgRes> ptImgResList = ptImgs.stream().map(PtImgRes::createRes).toList();
+
+        //when
+        BmDetailRes bmDetail = bmService.getBmDetail(member.getId(), bm.getId());
+
+        //then
+        assertThat(bmDetail.id()).isEqualTo(bm.getId());
+        assertThat(bmDetail.name()).isEqualTo(bm.getName());
+        assertThat(bmDetail.company()).isEqualTo(bm.getCompany());
+        assertThat(bmDetail.intro()).isEqualTo(bm.getIntro());
+        assertThat(bmDetail.mainCategory()).isEqualTo(bm.getMainCategory().getKoreanName());
+        assertThat(bmDetail.subCategory()).isEqualTo(bm.getSubCategory().getKoreanName());
+        assertThat(bmDetail.logoImg()).isEqualTo(bm.getLogoImg());
+        assertThat(bmDetail.description()).isEqualTo(bm.getDescription());
+        assertThat(bmDetail.descriptionImg()).isEqualTo(bm.getDescriptionImg());
+        assertThat(bmDetail.address()).isEqualTo(bm.getAddress());
+        assertThat(bmDetail.createdAt()).isEqualTo(bm.getCreatedAt());
+        assertThat(bmDetail.longPitchUrl()).isEqualTo(bm.getLongPitchUrl());
+        assertThat(bmDetail.spURL()).isEqualTo(bm.getShortPitchURL());
+        assertThat(bmDetail.isLiked()).isFalse();
+        assertThat(bmDetail.likeCnt()).isEqualTo(0);
+        assertThat(bmDetail.ptImgResList()).isEqualTo(ptImgResList);
+    }
+
+    @Test
+    void BM_조회_성공_좋아요_존재() {
+        //given
+        Member member_01 = saveMember();
+        Member member_02 = saveMember();
+        Bm bm = saveBm(member_01);
+        myBmRepository.save(new MyBm(member_01, bm));
+        myBmRepository.save(new MyBm(member_02, bm));
+
+        List<PtImg> ptImgs = createPtImgs(bm);
+        bm.updatePtImgs(ptImgs);
+        List<PtImgRes> ptImgResList = ptImgs.stream().map(PtImgRes::createRes).toList();
+
+        //when
+        BmDetailRes bmDetail = bmService.getBmDetail(member_01.getId(), bm.getId());
+
+        //then
+        assertThat(bmDetail.id()).isEqualTo(bm.getId());
+        assertThat(bmDetail.name()).isEqualTo(bm.getName());
+        assertThat(bmDetail.company()).isEqualTo(bm.getCompany());
+        assertThat(bmDetail.intro()).isEqualTo(bm.getIntro());
+        assertThat(bmDetail.mainCategory()).isEqualTo(bm.getMainCategory().getKoreanName());
+        assertThat(bmDetail.subCategory()).isEqualTo(bm.getSubCategory().getKoreanName());
+        assertThat(bmDetail.logoImg()).isEqualTo(bm.getLogoImg());
+        assertThat(bmDetail.description()).isEqualTo(bm.getDescription());
+        assertThat(bmDetail.descriptionImg()).isEqualTo(bm.getDescriptionImg());
+        assertThat(bmDetail.address()).isEqualTo(bm.getAddress());
+        assertThat(bmDetail.createdAt()).isEqualTo(bm.getCreatedAt());
+        assertThat(bmDetail.longPitchUrl()).isEqualTo(bm.getLongPitchUrl());
+        assertThat(bmDetail.spURL()).isEqualTo(bm.getShortPitchURL());
+        assertThat(bmDetail.isLiked()).isTrue();
+        assertThat(bmDetail.likeCnt()).isEqualTo(2);
+        assertThat(bmDetail.ptImgResList()).isEqualTo(ptImgResList);
+    }
+
+    @Test
+    void BM_조회_실패() {
+        //given
+        Member member = saveMember();
+        Long invalidId = Long.MAX_VALUE;
+
+        //when
+        GeneralHandler e_1 = assertThrows(GeneralHandler.class, () -> bmService.getBmDetail(invalidId, invalidId));
+        GeneralHandler e_2 = assertThrows(GeneralHandler.class, () -> bmService.getBmDetail(member.getId(), invalidId));
+
+        //then
+        assertThat(e_1.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_NOT_FOUND);
+        assertThat(e_2.getErrorStatus()).isEqualTo(ErrorStatus.BM_NOT_FOUND);
+    }
+
+    @Test
+    void BM_수정_성공() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+
+        final String updatedName = "updated_bm_name";
+        final MainCategory updatedMainCategory = MainCategory.COMMUNICATION_SECURITY_DATA;
+        final SubCategory updatedSubCategory = SubCategory.SAAS;
+        final String updatedCompany = "updated_bm_company";
+        final String updatedLogoImgUrl = "updated_bm_logo_img_url";
+        final String updatedIntro = "updated_bm_intro";
+        final String updatedDescription = "updated_bm_description";
+        final String updatedDescriptionImgUrl = "updated_bm_description_img_url";
+        final String updatedAddress = "updated_bm_address";
+        final Long updatedValuationCap = 200000L;
+        final Integer updatedGoalInvestment = 2000;
+        final Integer updatedMaxIssuedShare = 2000;
+        final LocalDate updatedDeadline = LocalDate.now().plusDays(30);
+        final String updatedLongPitchUrl = "updated_bm_longPitchUrl";
+
+        UpdateBmReq updateBmReq = new UpdateBmReq(updatedName, updatedMainCategory,
+                updatedSubCategory, updatedCompany, updatedIntro, updatedDescription,
+                updatedAddress, updatedValuationCap, updatedGoalInvestment,
+                updatedMaxIssuedShare, updatedDeadline, updatedLongPitchUrl
+        );
+
+        when(s3Uploader.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
+                .thenReturn(updatedLogoImgUrl);
+        when(s3Uploader.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
+                .thenReturn(updatedDescriptionImgUrl);
+
+        //when
+        bmService.updateBm(member.getId(), bm.getId(), updateBmReq, LOGO_IMG, DESCRIPTION_IMG);
+
+        //then
+        Bm updatedBm = bmRepository.findById(bm.getId()).orElseThrow();
+        assertThat(updatedBm.getName()).isEqualTo(updatedName);
+        assertThat(updatedBm.getMainCategory()).isEqualTo(updatedMainCategory);
+        assertThat(updatedBm.getSubCategory()).isEqualTo(updatedSubCategory);
+        assertThat(updatedBm.getCompany()).isEqualTo(updatedCompany);
+        assertThat(updatedBm.getLogoImg()).isEqualTo(updatedLogoImgUrl);
+        assertThat(updatedBm.getIntro()).isEqualTo(updatedIntro);
+        assertThat(updatedBm.getDescription()).isEqualTo(updatedDescription);
+        assertThat(updatedBm.getDescriptionImg()).isEqualTo(updatedDescriptionImgUrl);
+        assertThat(updatedBm.getAddress()).isEqualTo(updatedAddress);
+        assertThat(updatedBm.getValuationCap()).isEqualTo(updatedValuationCap);
+        assertThat(updatedBm.getGoalInvestment()).isEqualTo(updatedGoalInvestment);
+        assertThat(updatedBm.getMaxIssuedShare()).isEqualTo(updatedMaxIssuedShare);
+        assertThat(updatedBm.getDeadline()).isEqualTo(updatedDeadline);
+        assertThat(updatedBm.getLongPitchUrl()).isEqualTo(updatedLongPitchUrl);
+    }
+
+    @Test
+    void BM_수정_실패() {
+        //given
+        Member member_01 = saveMember();
+        Bm bm = saveBm(member_01);
+
+        final String UPDATED_NAME = "update_bm_name";
+        final MainCategory UPDATED_MAIN_CATEGORY = MainCategory.COMMUNICATION_SECURITY_DATA;
+        final SubCategory UPDATED_SUB_CATEGORY = SubCategory.SAAS;
+        final String UPDATED_COMPANY = "update_bm_company";
+        final String UPDATED_INTRO = "update_bm_intro";
+        final String UPDATED_DESCRIPTION = "update_bm_description";
+        final String UPDATED_ADDRESS = "update_bm_address";
+        final Long UPDATED_VALUATION_CAP = 200000L;
+        final Integer UPDATED_GOAL_INVESTMENT = 2000;
+        final Integer UPDATED_MAX_ISSUED_SHARE = 2000;
+        final LocalDate UPDATED_DEADLINE = LocalDate.now().plusDays(30);
+        final String UPDATED_LONG_PITCH_URL = "update_bm_longPitchUrl";
+
+        UpdateBmReq updateBmReq = new UpdateBmReq(UPDATED_NAME, UPDATED_MAIN_CATEGORY,
+                UPDATED_SUB_CATEGORY, UPDATED_COMPANY, UPDATED_INTRO, UPDATED_DESCRIPTION,
+                UPDATED_ADDRESS, UPDATED_VALUATION_CAP, UPDATED_GOAL_INVESTMENT,
+                UPDATED_MAX_ISSUED_SHARE, UPDATED_DEADLINE, UPDATED_LONG_PITCH_URL
+        );
+
+        Long invalidId = Long.MAX_VALUE;
+        Member member_02 = saveMember();
+
+        //when
+        GeneralHandler e_1 = assertThrows(GeneralHandler.class, () -> bmService.updateBm(invalidId, bm.getId(), updateBmReq, null, null));
+        GeneralHandler e_2 = assertThrows(GeneralHandler.class, () -> bmService.updateBm(member_01.getId(), invalidId, updateBmReq, null, null));
+        GeneralHandler e_3 = assertThrows(GeneralHandler.class, () -> bmService.updateBm(member_02.getId(), bm.getId(), updateBmReq, null, null));
+
+        //then
+        assertThat(e_1.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_NOT_FOUND);
+        assertThat(e_2.getErrorStatus()).isEqualTo(ErrorStatus.BM_NOT_FOUND);
+        assertThat(e_3.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_FORBIDDEN);
+    }
+
+    @Test
+    void BM_PT_IMG_수정_성공() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+
+        List<MultipartFile> ptImgs = List.of(
+                new MockMultipartFile(
+                        "img_1", "img_1.png", "image/png", "img1".getBytes()),
+                new MockMultipartFile(
+                        "img_2", "img_2.png", "image/png", "img2".getBytes()),
+                new MockMultipartFile(
+                        "img_3", "img_3.png", "image/png", "img3".getBytes())
+        );
+
+        for (int i = 0; i < ptImgs.size(); i++) {
+            String fakeUrl = "fake_" + (i + 1);
+            when(s3Uploader.uploadFile(ptImgs.get(i), S3UploadTarget.COMPANY_PT))
+                    .thenReturn(fakeUrl);
+        }
+
+        //when
+        bmService.updatePtImgs(member.getId(), bm.getId(), ptImgs);
+
+        //then
+        Bm updatedBm = bmRepository.findById(bm.getId()).orElseThrow();
+        List<PtImg> updatedPtImgs = updatedBm.getPtImgs();
+
+        assertThat(updatedPtImgs).hasSize(ptImgs.size());
+        for (int i = 0; i < ptImgs.size(); i++) {
+            assertThat(updatedPtImgs.get(i).getSerialNum()).isEqualTo(i);
+            assertThat(updatedPtImgs.get(i).getBm().getId()).isEqualTo(updatedBm.getId());
+            assertThat(updatedPtImgs.get(i).getImg()).isEqualTo("fake_" + (i + 1));
+        }
+    }
+
+    @Test
+    void BM_PT_IMG_수정_실패() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+
+        Long invalidId = Long.MAX_VALUE;
+        Member member_02 = saveMember();
+
+        //when
+        bmService.updatePtImgs(member.getId(), bm.getId(), null);
+        GeneralHandler e_1 = assertThrows(GeneralHandler.class, () -> bmService.updatePtImgs(invalidId, bm.getId(), null));
+        GeneralHandler e_2 = assertThrows(GeneralHandler.class, () -> bmService.updatePtImgs(member.getId(), invalidId, null));
+        GeneralHandler e_3 = assertThrows(GeneralHandler.class, () -> bmService.updatePtImgs(member_02.getId(), bm.getId(), null));
+
+        //then
+        assertThat(e_1.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_NOT_FOUND);
+        assertThat(e_2.getErrorStatus()).isEqualTo(ErrorStatus.BM_NOT_FOUND);
+        assertThat(e_3.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_FORBIDDEN);
+    }
+
+    @Test
+    void BM_삭제_성공() {
+        //given
+        Member member = saveMember();
+        Bm bm = saveBm(member);
+
+        //when
+        bmService.deleteBm(member.getId(), bm.getId());
+
+        //then
+        List<Bm> all = bmRepository.findAll();
+        assertThat(all.size()).isEqualTo(0);
+    }
+
+    @Test
+    void BM_삭제_실패() {
+        //given
+        Member member_01 = saveMember();
+        Bm bm = saveBm(member_01);
+
+        Long invalidId = Long.MAX_VALUE;
+        Member member_02 = saveMember();
+
+        //when
+        GeneralHandler e_1 = assertThrows(GeneralHandler.class, () -> bmService.deleteBm(invalidId, bm.getId()));
+        GeneralHandler e_2 = assertThrows(GeneralHandler.class, () -> bmService.deleteBm(member_01.getId(), invalidId));
+        GeneralHandler e_3 = assertThrows(GeneralHandler.class, () -> bmService.deleteBm(member_02.getId(), bm.getId()));
+
+        //then
+        assertThat(e_1.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_NOT_FOUND);
+        assertThat(e_2.getErrorStatus()).isEqualTo(ErrorStatus.BM_NOT_FOUND);
+        assertThat(e_3.getErrorStatus()).isEqualTo(ErrorStatus.MEMBER_FORBIDDEN);
+    }
+}


### PR DESCRIPTION
## ⭐ Summary

> #73 

<br>

## 📌 Tasks

1. EntityFacade 구현
    - Facade패턴을 통해 엔티티의 단순 조회를 담당
    - 단순 조회를 위해 여러 repo를 의존하게 되는 문제를 해결
2. BM 생성/수정/삭제 기능 구현
3. BM 상세 조회 시 쿼리 에러 해결
4. BM CRUD 테스트 코드 작성


<br>

## ETC
### 1. MappingJackson2HttpMessageConverter 등록
swagger에서는 각 데이터에 대해 content-type을 지정해줄 수 없기 때문에
@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE)을 통해 MULTIPART_FORM_DATA를 지정하여 FILE과 JSON을 같이 보낼 수 있게 해주었다.

하지만 여전히 각 데이터에 대해 content-type을 지정해줄 수 없기 때문에 기본 값인 application/octet-stream으로 요청된다.

스프링은 기본적으로 application/octet-stream을 처리하여 응답해줄 수 있는 컨버터가 존재하지 않기 때문에 에러가 발생한다.
따라서 이를 처리하지 못하도록 컨버터를 등록하여 해결

### 2. S3Uploader Mocking을 통한 테스트 코드
각 api에 파일 업로드 기능을 포함되어 있고 테스트 코드마다 S3에 업로드 되면 매우 비효율적
따라서 S3Uploader을 모킹하여 테스트 코드 작성

### 3. BM 상세 조회 시 쿼리 분리
- BM 상세 조회 쿼리는 BM 정보, isLiked, bm의 총 좋아요 수, ptImgs fetch join 등 너무 많은 정보를 한 번에 가져오는 과정 중 에러 발생
- 각 쿼리를 분리하여 해결
  - BM 정보, isLiked 조회
  - bm의 총 좋아요 수 조회
  - ptImgs 조회