### PR TITLE
[feat] sp 생성/수정/삭제 기능 구현

### DIFF
--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -1,14 +1,14 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.service.SpService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -17,6 +17,15 @@ import java.util.List;
 @RestController
 public class SpController {
     private final SpService spService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse createSp(@AuthenticationPrincipal Long memberId,
+                                      @RequestPart CreateSpReq createSpReq,
+                                      @RequestPart(required = false) MultipartFile spVideo,
+                                      @RequestPart(required = false) MultipartFile thumbnailImg) {
+        spService.createSp(memberId, createSpReq, spVideo, thumbnailImg);
+        return CustomApiResponse.onSuccess();
+    }
 
     @GetMapping
     public CustomApiResponse<List<SpDetailRes>> getSpDetails(@AuthenticationPrincipal Long memberId) {
@@ -31,4 +40,20 @@ public class SpController {
         return CustomApiResponse.onSuccess(spDetailRes);
     }
 
+    @PutMapping(value = "/{spId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CustomApiResponse updateSp(@AuthenticationPrincipal Long memberId,
+                                      @PathVariable Long spId,
+                                      @RequestPart String name,
+                                      @RequestPart(required = false) MultipartFile spVideo,
+                                      @RequestPart(required = false) MultipartFile thumbnailImg) {
+        spService.updateSp(memberId, spId, name, spVideo, thumbnailImg);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @DeleteMapping("/{spId}")
+    public CustomApiResponse deleteSp(@AuthenticationPrincipal Long memberId,
+                                      @PathVariable Long spId) {
+        spService.deleteSp(memberId, spId);
+        return CustomApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/pitchain/dto/SpWithLikeDto.java
+++ b/src/main/java/com/pitchain/dto/SpWithLikeDto.java
@@ -9,5 +9,4 @@ import lombok.Getter;
 public class SpWithLikeDto {
     Sp sp;
     boolean isLiked;
-    Long likeCnt;
 }

--- a/src/main/java/com/pitchain/dto/req/CreateSpReq.java
+++ b/src/main/java/com/pitchain/dto/req/CreateSpReq.java
@@ -1,0 +1,7 @@
+package com.pitchain.dto.req;
+
+public record CreateSpReq(
+        Long bmId,
+        String name
+) {
+}

--- a/src/main/java/com/pitchain/dto/res/SpDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/SpDetailRes.java
@@ -17,9 +17,9 @@ public record SpDetailRes(
         String subCategory,
         String company,
         boolean isLiked,
-        Long likeCnt
+        long likeCnt
 ) {
-    public static SpDetailRes createRes(SpWithLikeDto spWithLikeDto) {
+    public static SpDetailRes createRes(SpWithLikeDto spWithLikeDto, long likeCnt) {
         Sp sp = spWithLikeDto.getSp();
         Bm bm = sp.getBm();
         return SpDetailRes.builder()
@@ -33,7 +33,7 @@ public record SpDetailRes(
                 .subCategory(bm.getSubCategory().getKoreanName())
                 .company(bm.getCompany())
                 .isLiked(spWithLikeDto.isLiked())
-                .likeCnt(spWithLikeDto.getLikeCnt())
+                .likeCnt(likeCnt)
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/entity/Sp.java
+++ b/src/main/java/com/pitchain/entity/Sp.java
@@ -31,4 +31,21 @@ public class Sp extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    public Sp(Bm bm, String shortPitchURL, String thumbnailImg, String name) {
+        this.bm = bm;
+        this.shortPitchURL = shortPitchURL;
+        this.thumbnailImg = thumbnailImg;
+        this.name = name;
+        this.views = 0;
+    }
+
+    public boolean isOwner(Long memberId) {
+        return bm.getMember().getId().equals(memberId);
+    }
+
+    public void update(Sp updateSp) {
+        this.shortPitchURL = updateSp.shortPitchURL;
+        this.thumbnailImg = updateSp.thumbnailImg;
+        this.name = updateSp.name;
+    }
 }

--- a/src/main/java/com/pitchain/repository/SpRepository.java
+++ b/src/main/java/com/pitchain/repository/SpRepository.java
@@ -13,8 +13,7 @@ public interface SpRepository extends JpaRepository<Sp, Long> {
     @Query("""
                 SELECT DISTINCT new com.pitchain.dto.SpWithLikeDto(
                     s,
-                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
-                    COUNT(mb.id)
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END
                 )
                 FROM Sp s
                 LEFT JOIN FETCH s.bm b
@@ -25,8 +24,7 @@ public interface SpRepository extends JpaRepository<Sp, Long> {
     @Query("""
                 SELECT DISTINCT new com.pitchain.dto.SpWithLikeDto(
                     s,
-                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END,
-                    COUNT(mb.id)
+                    CASE WHEN mb.member.id IS NOT NULL THEN true ELSE false END
                 )
                 FROM Sp s
                 LEFT JOIN FETCH s.bm b

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -1,13 +1,21 @@
 package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.S3UploadTarget;
 import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.dto.SpWithLikeDto;
+import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.Sp;
+import com.pitchain.repository.EntityFacade;
+import com.pitchain.repository.MyBmRepository;
 import com.pitchain.repository.SpRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,7 +23,21 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class SpService {
+    private final EntityFacade entityFacade;
     private final SpRepository spRepository;
+    private final MyBmRepository myBmRepository;
+    private final S3Service s3Service;
+
+    public void createSp(Long memberId, CreateSpReq createSpReq, MultipartFile spVid, MultipartFile thumbnailImg) {
+        Member member = entityFacade.getMember(memberId);
+        Bm bm = entityFacade.getBm(createSpReq.bmId());
+
+        String spVidURL = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
+        String thumbnailImgURL = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
+
+        Sp sp = new Sp(bm, spVidURL, thumbnailImgURL, createSpReq.name());
+        spRepository.save(sp);
+    }
 
     @Transactional(readOnly = true)
     public List<SpDetailRes> getSpDetails(Long memberId) {
@@ -37,5 +59,36 @@ public class SpService {
         long likeCnt = myBmRepository.countByBm(spWithLikeDto.getSp().getBm());
 
         return SpDetailRes.createRes(spWithLikeDto, likeCnt);
+    }
+
+    public void updateSp(Long memberId, Long spId, String name, MultipartFile spVid, MultipartFile thumbnailImg) {
+        Member member = entityFacade.getMember(memberId);
+        Sp sp = entityFacade.getSp(spId);
+
+        validateSpOwner(sp, member);
+
+        s3Service.deleteFile(sp.getShortPitchURL());
+        s3Service.deleteFile(sp.getThumbnailImg());
+
+        String spVidURL = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
+        String thumbnailImgURL = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
+
+        Sp updateSp = new Sp(sp.getBm(), spVidURL, thumbnailImgURL, name);
+        sp.update(updateSp);
+    }
+
+    public void deleteSp(Long memberId, Long spId) {
+        Member member = entityFacade.getMember(memberId);
+        Sp sp = entityFacade.getSp(spId);
+
+        validateSpOwner(sp, member);
+
+        spRepository.delete(sp);
+    }
+
+    private static void validateSpOwner(Sp sp, Member member) {
+        if (!sp.isOwner(member.getId())) {
+            throw new GeneralHandler(ErrorStatus.MEMBER_FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -20,7 +20,13 @@ public class SpService {
     @Transactional(readOnly = true)
     public List<SpDetailRes> getSpDetails(Long memberId) {
         List<SpWithLikeDto> spWithLikeDtos = spRepository.findAllWithLike(memberId);
-        return spWithLikeDtos.stream().map(SpDetailRes::createRes).toList();
+        return spWithLikeDtos.stream()
+                .map(spWithLikeDto -> {
+                    Sp sp = spWithLikeDto.getSp();
+                    long likeCnt = myBmRepository.countByBm(sp.getBm());
+                    return SpDetailRes.createRes(spWithLikeDto, likeCnt);
+                })
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -28,6 +34,8 @@ public class SpService {
         SpWithLikeDto spWithLikeDto = spRepository.findSpWithLike(memberId, spId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND));
 
-        return SpDetailRes.createRes(spWithLikeDto);
+        long likeCnt = myBmRepository.countByBm(spWithLikeDto.getSp().getBm());
+
+        return SpDetailRes.createRes(spWithLikeDto, likeCnt);
     }
 }

--- a/src/test/java/com/pitchain/service/SpServiceTest.java
+++ b/src/test/java/com/pitchain/service/SpServiceTest.java
@@ -1,0 +1,214 @@
+package com.pitchain.service;
+
+import com.pitchain.common.constant.Country;
+import com.pitchain.common.constant.MainCategory;
+import com.pitchain.common.constant.S3UploadTarget;
+import com.pitchain.common.constant.SubCategory;
+import com.pitchain.dto.req.CreateSpReq;
+import com.pitchain.dto.res.SpDetailRes;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.MyBm;
+import com.pitchain.entity.Sp;
+import com.pitchain.repository.BmRepository;
+import com.pitchain.repository.MemberRepository;
+import com.pitchain.repository.MyBmRepository;
+import com.pitchain.repository.SpRepository;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@SpringBootTest
+class SpServiceTest {
+
+    @MockBean
+    private S3Service s3Service;
+
+    @Autowired
+    private SpService spService;
+    @Autowired
+    private SpRepository spRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BmRepository bmRepository;
+    @Autowired
+    private MyBmRepository myBmRepository;
+
+    private Member saveMember() {
+        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+    }
+
+    private Bm saveBm(Member member) {
+        return bmRepository.save(new Bm(member, "bm_name", MainCategory.FOOD, SubCategory.BEVERAGE_COFFEE, "bm_company", "bm_logo_img_url",
+                "bm_intro", "bm_description", "bm_description_img_url", "bm_address", 100000L,
+                1000, 1000, LocalDate.now(), "bm_longPitchUrl"));
+    }
+
+    private Sp saveSp(Bm bm) {
+        return spRepository.save(
+                new Sp(bm, SP_VID.getOriginalFilename(), THUMBNAIL_IMG.getOriginalFilename(), SP_NAME));
+    }
+
+    @BeforeEach
+    void setUp() {
+        member = saveMember();
+        bm = saveBm(member);
+    }
+
+    private Member member;
+    private Bm bm;
+
+    private static final String SP_NAME = "sp_name";
+    private static final MockMultipartFile SP_VID = new MockMultipartFile(
+            "sp_vid", "sp_vid.mp4", "video/mp4", "test data 1".getBytes());
+    private static final MockMultipartFile THUMBNAIL_IMG = new MockMultipartFile(
+            "thumbnail_img", "thumbnail_img.png", "image/png", "test data 2".getBytes());
+
+
+    @Test
+    void SP_생성_성공() {
+        //given
+        CreateSpReq createSpReq = new CreateSpReq(bm.getId(), SP_NAME);
+
+        when(s3Service.uploadFile(SP_VID, S3UploadTarget.COMPANY_VIDEO))
+                .thenReturn(SP_VID.getOriginalFilename());
+        when(s3Service.uploadFile(THUMBNAIL_IMG, S3UploadTarget.COMPANY_THUMBNAIL))
+                .thenReturn(THUMBNAIL_IMG.getOriginalFilename());
+
+        //when
+        spService.createSp(member.getId(), createSpReq, SP_VID, THUMBNAIL_IMG);
+
+        //then
+        List<Sp> all = spRepository.findAll();
+        Sp sp = all.get(0);
+        assertThat(sp.getBm()).isEqualTo(bm);
+        assertThat(sp.getShortPitchURL()).isEqualTo(SP_VID.getOriginalFilename());
+        assertThat(sp.getThumbnailImg()).isEqualTo(THUMBNAIL_IMG.getOriginalFilename());
+        assertThat(sp.getName()).isEqualTo(SP_NAME);
+    }
+
+    @Test
+    void SP_조회_성공_좋아요_없음() {
+        //given
+        Sp sp = saveSp(bm);
+
+        //when
+        SpDetailRes spDetail = spService.getSpDetail(member.getId(), sp.getId());
+
+        //then
+        assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
+        assertThat(spDetail.shortPitchURL()).isEqualTo(sp.getShortPitchURL());
+        assertThat(spDetail.thumbnailImg()).isEqualTo(sp.getThumbnailImg());
+        assertThat(spDetail.views()).isEqualTo(sp.getViews());
+        assertThat(spDetail.name()).isEqualTo(sp.getName());
+        assertThat(spDetail.logoImg()).isEqualTo(sp.getBm().getLogoImg());
+        assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
+        assertThat(spDetail.subCategory()).isEqualTo(sp.getBm().getSubCategory().getKoreanName());
+        assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());
+        assertThat(spDetail.isLiked()).isEqualTo(false);
+        assertThat(spDetail.likeCnt()).isEqualTo(0L);
+    }
+
+    @Test
+    void SP_조회_성공_좋아요_존재() {
+        //given
+        Member newMember = saveMember();
+        Sp sp = saveSp(bm);
+        myBmRepository.save(new MyBm(member, bm));
+        myBmRepository.save(new MyBm(newMember, bm));
+
+        //when
+        SpDetailRes spDetail = spService.getSpDetail(member.getId(), sp.getId());
+
+        //then
+        assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
+        assertThat(spDetail.shortPitchURL()).isEqualTo(sp.getShortPitchURL());
+        assertThat(spDetail.thumbnailImg()).isEqualTo(sp.getThumbnailImg());
+        assertThat(spDetail.views()).isEqualTo(sp.getViews());
+        assertThat(spDetail.name()).isEqualTo(sp.getName());
+        assertThat(spDetail.logoImg()).isEqualTo(sp.getBm().getLogoImg());
+        assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
+        assertThat(spDetail.subCategory()).isEqualTo(sp.getBm().getSubCategory().getKoreanName());
+        assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());
+        assertThat(spDetail.isLiked()).isEqualTo(true);
+        assertThat(spDetail.likeCnt()).isEqualTo(2L);
+    }
+
+    @Test
+    void SP_전체_조회() {
+        //given
+        Sp sp_1 = saveSp(bm);
+
+        Member newMember = saveMember();
+        Bm newBm = saveBm(newMember);
+        Sp sp_2 = saveSp(newBm);
+
+        //when
+        List<SpDetailRes> spDetails = spService.getSpDetails(member.getId());
+
+        //then
+        assertThat(spDetails).hasSize(2);
+        boolean isContainBmIds = spDetails.stream()
+                .map(SpDetailRes::bmId)
+                .toList()
+                .containsAll(
+                        List.of(sp_1.getBm().getId(), sp_2.getBm().getId())
+                );
+        assertThat(isContainBmIds).isTrue();
+    }
+
+    @Test
+    void SP_수정_성공() {
+        //given
+        Sp sp = saveSp(bm);
+
+        String newName = "new_name";
+        MockMultipartFile newSpVid = new MockMultipartFile(
+                "new_sp_vid", "new_sp_vid.mp4", "video/mp4", "test data 3".getBytes());
+        MockMultipartFile newThumbnailImg = new MockMultipartFile(
+                "new_thumbnail_img", "new_thumbnail_img.png", "image/png", "test data 4".getBytes());
+
+        when(s3Service.uploadFile(newSpVid, S3UploadTarget.COMPANY_VIDEO))
+                .thenReturn(newSpVid.getOriginalFilename());
+        when(s3Service.uploadFile(newThumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL))
+                .thenReturn(newThumbnailImg.getOriginalFilename());
+
+        //when
+        spService.updateSp(member.getId(), sp.getId(), newName, newSpVid, newThumbnailImg);
+
+        //then
+        List<Sp> all = spRepository.findAll();
+        Sp updatedSp = all.get(0);
+        assertThat(updatedSp.getBm()).isEqualTo(bm);
+        assertThat(updatedSp.getShortPitchURL()).isEqualTo(newSpVid.getOriginalFilename());
+        assertThat(updatedSp.getThumbnailImg()).isEqualTo(newThumbnailImg.getOriginalFilename());
+        assertThat(updatedSp.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    void SP_삭제_성공() {
+        //given
+        Sp sp = saveSp(bm);
+
+        //when
+        spService.deleteSp(member.getId(), sp.getId());
+
+        //then
+        List<Sp> all = spRepository.findAll();
+        assertThat(all).isEmpty();
+    }
+}


### PR DESCRIPTION
## ⭐ Summary

> #72 

<br>

## 📌 Tasks

1. sp 생성/수정/삭제 기능 구현
2. sp 조회 쿼리 에러 해결
3. sp crud 테스트

<br>

## ETC
마찬가지로 기존 sp 조회 쿼리에서 bm의 전체 좋아요인 likeCnt를 조회하는 쿼리를 분리하여 해결했습니다
