### PR TITLE
[fix] /health-check jwt 검증 로직 생략

### DIFF
--- a/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pitchain/jwt/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/oauth**",
             "/resources/**", "/favicon.ico", // resource
             "/swagger-ui/**", "/api-docs/**", "/v3/api-docs**", "/v3/api-docs/**", // swagger
+            "/health-check", // health check
             "/dev**" // 개발용
     };
 


### PR DESCRIPTION
## ⭐ Summary
> #90

<br>

## 📌 Tasks
1. /health-check jwt 검증 로직 생략

<br>

## ETC

ALB의 대상 그룹에 대한 헬스 체크 경로를 기존 "/"에서 "/health-check"로 변경 하였고, 해당 경로에 대해 jwt 검증이 생략되도록 적용
