### PR TITLE
[feat] SP 조회 시 m3u8 파일 반환하기

### DIFF
--- a/src/main/java/com/pitchain/controller/BmController.java
+++ b/src/main/java/com/pitchain/controller/BmController.java
@@ -23,8 +23,8 @@ public class BmController {
     public CustomApiResponse createBm(@AuthenticationPrincipal Long memberId,
                                       @RequestPart CreateBmReq createBmReq,
                                       @RequestPart(required = false) MultipartFile logoImg,
-                                      @RequestPart(required = false) MultipartFile descriptionImg) {
-        bmService.createBm(memberId, createBmReq, logoImg, descriptionImg);
+                                      @RequestPart(required = false) MultipartFile descImg) {
+        bmService.createBm(memberId, createBmReq, logoImg, descImg);
         return CustomApiResponse.onSuccess();
     }
 
@@ -40,8 +40,8 @@ public class BmController {
                                                    @PathVariable("bmId") Long bmId,
                                                    @RequestPart UpdateBmReq updateBmReq,
                                                    @RequestPart(required = false) MultipartFile logoImg,
-                                                   @RequestPart(required = false) MultipartFile descriptionImg) {
-        bmService.updateBm(memberId, bmId, updateBmReq, logoImg, descriptionImg);
+                                                   @RequestPart(required = false) MultipartFile descImg) {
+        bmService.updateBm(memberId, bmId, updateBmReq, logoImg, descImg);
         return CustomApiResponse.onSuccess();
     }
 

--- a/src/main/java/com/pitchain/controller/S3Controller.java
+++ b/src/main/java/com/pitchain/controller/S3Controller.java
@@ -9,6 +9,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import static com.pitchain.service.S3Service.getFileURL;
+
 @RestController
 @RequiredArgsConstructor
 public class S3Controller {
@@ -20,7 +22,7 @@ public class S3Controller {
     public CustomApiResponse<String> uploadFile(@RequestPart MultipartFile file,
                                                 @RequestParam S3UploadTarget s3UploadTarget) {
         String fileKey = s3Service.uploadFile(file, s3UploadTarget);
-        String fileURL = s3Service.getFileURL(fileKey);
+        String fileURL = getFileURL(fileKey);
         return CustomApiResponse.onSuccess(fileURL);
     }
 

--- a/src/main/java/com/pitchain/controller/S3Controller.java
+++ b/src/main/java/com/pitchain/controller/S3Controller.java
@@ -26,10 +26,17 @@ public class S3Controller {
         return CustomApiResponse.onSuccess(fileURL);
     }
 
-    @Operation(summary = "파일(이미지, 동영상) 삭제 / 개발용")
-    @DeleteMapping("/s3")
-    public CustomApiResponse deleteFile(@RequestParam String fileKey) {
-        s3Service.deleteFile(fileKey);
+    @Operation(summary = "파일(이미지) 삭제 / 개발용")
+    @DeleteMapping("/s3/images")
+    public CustomApiResponse deleteImg(@RequestParam String fileKey) {
+        s3Service.deleteImg(fileKey);
+        return CustomApiResponse.onSuccess();
+    }
+
+    @Operation(summary = "파일(동영상) 삭제 / 개발용")
+    @DeleteMapping("/s3/videos")
+    public CustomApiResponse deleteVid(@RequestParam String fileKey) {
+        s3Service.deleteVid(fileKey);
         return CustomApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/pitchain/controller/S3Controller.java
+++ b/src/main/java/com/pitchain/controller/S3Controller.java
@@ -9,8 +9,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.pitchain.service.S3Service.getFileURL;
-
 @RestController
 @RequiredArgsConstructor
 public class S3Controller {
@@ -22,7 +20,7 @@ public class S3Controller {
     public CustomApiResponse<String> uploadFile(@RequestPart MultipartFile file,
                                                 @RequestParam S3UploadTarget s3UploadTarget) {
         String fileKey = s3Service.uploadFile(file, s3UploadTarget);
-        String fileURL = getFileURL(fileKey);
+        String fileURL = s3Service.getFileURL(fileKey);
         return CustomApiResponse.onSuccess(fileURL);
     }
 

--- a/src/main/java/com/pitchain/controller/S3Controller.java
+++ b/src/main/java/com/pitchain/controller/S3Controller.java
@@ -19,14 +19,15 @@ public class S3Controller {
     @PostMapping(value = "/s3", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CustomApiResponse<String> uploadFile(@RequestPart MultipartFile file,
                                                 @RequestParam S3UploadTarget s3UploadTarget) {
-        String fileURL = s3Service.uploadFile(file, s3UploadTarget);
+        String fileKey = s3Service.uploadFile(file, s3UploadTarget);
+        String fileURL = s3Service.getFileURL(fileKey);
         return CustomApiResponse.onSuccess(fileURL);
     }
 
     @Operation(summary = "파일(이미지, 동영상) 삭제 / 개발용")
     @DeleteMapping("/s3")
-    public CustomApiResponse deleteFile(@RequestParam String fileURL) {
-        s3Service.deleteFile(fileURL);
+    public CustomApiResponse deleteFile(@RequestParam String fileKey) {
+        s3Service.deleteFile(fileKey);
         return CustomApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/pitchain/dto/req/CreateBmReq.java
+++ b/src/main/java/com/pitchain/dto/req/CreateBmReq.java
@@ -21,24 +21,24 @@ public record CreateBmReq(
         Long goalInvestment,
         Integer maxIssuedShare,
         LocalDate deadline,
-        String longPitchUrl
+        String longPitchURL
 ) {
-    public Bm createBm(Member member, String logoImg, String descriptionImg) {
+    public Bm createBm(Member member, String logoImgKey, String descImgKey) {
         return Bm.builder()
                 .member(member)
                 .name(name)
                 .mainCategory(mainCategory)
                 .company(company)
-                .logoImg(logoImg)
+                .logoImgKey(logoImgKey)
                 .intro(intro)
                 .description(description)
-                .descriptionImg(descriptionImg)
+                .descImgKey(descImgKey)
                 .address(address)
                 .valuationCap(valuationCap)
                 .goalInvestment(goalInvestment)
                 .maxIssuedShare(maxIssuedShare)
                 .deadline(deadline)
-                .longPitchUrl(longPitchUrl)
+                .longPitchURL(longPitchURL)
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/dto/req/UpdateBmReq.java
+++ b/src/main/java/com/pitchain/dto/req/UpdateBmReq.java
@@ -19,23 +19,23 @@ public record UpdateBmReq(
         Long goalInvestment,
         Integer maxIssuedShare,
         LocalDate deadline,
-        String longPitchUrl
+        String longPitchURL
 ) {
-    public Bm createBm(String logoImg, String descriptionImg) {
+    public Bm createBm(String logoImgKey, String descImgKey) {
         return Bm.builder()
                 .name(name)
                 .mainCategory(mainCategory)
                 .company(company)
-                .logoImg(logoImg)
+                .logoImgKey(logoImgKey)
                 .intro(intro)
                 .description(description)
-                .descriptionImg(descriptionImg)
+                .descImgKey(descImgKey)
                 .address(address)
                 .valuationCap(valuationCap)
                 .goalInvestment(goalInvestment)
                 .maxIssuedShare(maxIssuedShare)
                 .deadline(deadline)
-                .longPitchUrl(longPitchUrl)
+                .longPitchURL(longPitchURL)
                 .build();
     }
 }

--- a/src/main/java/com/pitchain/dto/res/BmDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/BmDetailRes.java
@@ -15,18 +15,19 @@ public record BmDetailRes(
         String intro,
         String mainCategory,
         List<String> subCategories,
-        String logoImg,
+        String logoImgURL,
         String description,
-        String descriptionImg,
+        String descImgURL,
         String address,
         LocalDateTime createdAt,
-        String longPitchUrl,
+        String longPitchURL,
         String spURL,
         boolean isLiked,
         long likeCnt,
         List<PtImgRes> ptImgResList
 ) {
-    public static BmDetailRes createRes(BmWithLikeDto bmWithLikeDto, long likeCnt, List<PtImgRes> ptImgResList, List<String> subCategories) {
+    public static BmDetailRes createRes(BmWithLikeDto bmWithLikeDto, long likeCnt, List<PtImgRes> ptImgResList, List<String> subCategories,
+                                        String spURL, String logoImgURL, String descImgURL) {
         Bm bm = bmWithLikeDto.getBm();
         return BmDetailRes.builder()
                 .id(bm.getId())
@@ -35,13 +36,13 @@ public record BmDetailRes(
                 .intro(bm.getIntro())
                 .mainCategory(bm.getMainCategory().getKoreanName())
                 .subCategories(subCategories)
-                .logoImg(bm.getLogoImg())
+                .logoImgURL(logoImgURL)
                 .description(bm.getDescription())
-                .descriptionImg(bm.getDescriptionImg())
+                .descImgURL(descImgURL)
                 .address(bm.getAddress())
                 .createdAt(bm.getCreatedAt())
-                .longPitchUrl(bm.getLongPitchUrl())
-                .spURL(bm.getShortPitchURL())
+                .longPitchURL(bm.getLongPitchURL())
+                .spURL(spURL)
                 .isLiked(bmWithLikeDto.isLiked())
                 .likeCnt(likeCnt)
                 .ptImgResList(ptImgResList)

--- a/src/main/java/com/pitchain/dto/res/CommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/CommentRes.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class CommentRes extends BaseCommentRes {
     private final Long writerId;
     private final String writerName;
-    private final String writerProfileImg;
+    private final String writerProfileImgURL;
     private final String content;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
@@ -20,19 +20,19 @@ public class CommentRes extends BaseCommentRes {
     @Builder
     public CommentRes(
             Long commentId, boolean delYN, List<ReplyCommentRes> replyComments,
-            Long writerId, String writerName, String writerProfileImg, String content,
+            Long writerId, String writerName, String writerProfileImgURL, String content,
             LocalDateTime createdAt, LocalDateTime updatedAt
     ) {
         super(commentId, delYN, replyComments);
         this.writerId = writerId;
         this.writerName = writerName;
-        this.writerProfileImg = writerProfileImg;
+        this.writerProfileImgURL = writerProfileImgURL;
         this.content = content;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    public static CommentRes createRes(Comment comment, List<ReplyCommentRes> replyComments) {
+    public static CommentRes createRes(Comment comment, List<ReplyCommentRes> replyComments, String writerProfileImgURL) {
         Member member = comment.getMember();
         return CommentRes.builder()
                 .commentId(comment.getId())
@@ -40,7 +40,7 @@ public class CommentRes extends BaseCommentRes {
                 .replyComments(replyComments)
                 .writerId(member.getId())
                 .writerName(member.getName())
-                .writerProfileImg(member.getProfileImg())
+                .writerProfileImgURL(writerProfileImgURL)
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())

--- a/src/main/java/com/pitchain/dto/res/PtImgRes.java
+++ b/src/main/java/com/pitchain/dto/res/PtImgRes.java
@@ -1,12 +1,10 @@
 package com.pitchain.dto.res;
 
-import com.pitchain.entity.PtImg;
-
 public record PtImgRes(
         int serialNum,
-        String img
+        String imgURL
 ) {
-    public static PtImgRes createRes(PtImg ptImg) {
-        return new PtImgRes(ptImg.getSerialNum(), ptImg.getImg());
+    public static PtImgRes createRes(int serialNum, String imgURL) {
+        return new PtImgRes(serialNum, imgURL);
     }
 }

--- a/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
+++ b/src/main/java/com/pitchain/dto/res/ReplyCommentRes.java
@@ -11,18 +11,18 @@ public record ReplyCommentRes(
         Long commentId,
         Long writerId,
         String writerName,
-        String writerProfileImg,
+        String writerProfileImgURL,
         String content,
         boolean delYN,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static ReplyCommentRes createRes(Comment comment) {
+    public static ReplyCommentRes createRes(Comment comment, String writerProfileImgURL) {
         Member member = comment.getMember();
         return ReplyCommentRes.builder()
                 .commentId(comment.getId())
                 .writerId(member.getId())
-                .writerProfileImg(member.getProfileImg())
+                .writerProfileImgURL(writerProfileImgURL)
                 .writerName(member.getName())
                 .content(comment.getContent())
                 .delYN(comment.isDelYN())

--- a/src/main/java/com/pitchain/dto/res/SpDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/SpDetailRes.java
@@ -10,27 +10,28 @@ import java.util.List;
 @Builder
 public record SpDetailRes(
         Long bmId,
-        String shortPitchURL,
-        String thumbnailImg,
+        String spURL,
+        String thumbnailImgURL,
         int views,
         String name,
-        String logoImg,
+        String logoImgURL,
         String mainCategory,
         List<String> subCategories,
         String company,
         boolean isLiked,
         long likeCnt
 ) {
-    public static SpDetailRes createRes(SpWithLikeDto spWithLikeDto, long likeCnt, List<String> subCategories) {
+    public static SpDetailRes createRes(SpWithLikeDto spWithLikeDto, String spURL, String thumbnailImgURL,
+                                        long likeCnt, List<String> subCategories, String logoImgURL) {
         Sp sp = spWithLikeDto.getSp();
         Bm bm = sp.getBm();
         return SpDetailRes.builder()
                 .bmId(sp.getBm().getId())
-                .shortPitchURL(sp.getShortPitchURL())
-                .thumbnailImg(sp.getThumbnailImg())
+                .spURL(spURL)
+                .thumbnailImgURL(thumbnailImgURL)
                 .views(sp.getViews())
                 .name(sp.getName())
-                .logoImg(bm.getLogoImg())
+                .logoImgURL(logoImgURL)
                 .mainCategory(bm.getMainCategory().getKoreanName())
                 .subCategories(subCategories)
                 .company(bm.getCompany())

--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -31,13 +31,13 @@ public class Bm extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MainCategory mainCategory;
     private String company;
-    private String logoImg;
+    private String logoImgKey;
     @Column(length = 100)
     private String intro;
     @Column(length = 10000)
     private String description;
 
-    private String descriptionImg;
+    private String descImgKey;
     private String address;
     @Positive
     private Long valuationCap;
@@ -46,7 +46,8 @@ public class Bm extends BaseEntity {
     @Positive
     private Integer maxIssuedShare;
     private LocalDate deadline;
-    private String longPitchUrl;
+    @Column(name = "long_pitch_url")
+    private String longPitchURL;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -72,30 +73,31 @@ public class Bm extends BaseEntity {
     }
 
     @Builder
-    public Bm(Member member, String name, MainCategory mainCategory, String company, String logoImg,
-              String intro, String description, String descriptionImg, String address,
+    public Bm(Member member, String name, MainCategory mainCategory, String company, String logoImgKey,
+              String intro, String description, String descImgKey, String address,
               Long valuationCap, Long goalInvestment, Integer maxIssuedShare,
-              LocalDate deadline, String longPitchUrl) {
+              LocalDate deadline, String longPitchURL) {
         this.member = member;
         this.name = name;
         this.mainCategory = mainCategory;
         this.company = company;
-        this.logoImg = logoImg;
+        this.logoImgKey = logoImgKey;
         this.intro = intro;
         this.description = description;
-        this.descriptionImg = descriptionImg;
+        this.descImgKey = descImgKey;
         this.address = address;
         this.valuationCap = valuationCap;
         this.goalInvestment = goalInvestment;
         this.maxIssuedShare = maxIssuedShare;
         this.deadline = deadline;
-        this.longPitchUrl = longPitchUrl;
+        this.longPitchURL = longPitchURL;
     }
 
-    public String getShortPitchURL() {
-        if (sp == null)
+    public String getSpKey() {
+        if (sp == null) {
             return Strings.EMPTY;
-        return sp.getShortPitchURL();
+        }
+        return sp.getSpKey();
     }
 
     public boolean isOwner(Long memberId) {
@@ -125,16 +127,16 @@ public class Bm extends BaseEntity {
         this.name = updateBm.getName();
         this.mainCategory = updateBm.getMainCategory();
         this.company = updateBm.getCompany();
-        this.logoImg = updateBm.getLogoImg();
+        this.logoImgKey = updateBm.getLogoImgKey();
         this.intro = updateBm.getIntro();
         this.description = updateBm.getDescription();
-        this.descriptionImg = updateBm.getDescriptionImg();
+        this.descImgKey = updateBm.getDescImgKey();
         this.address = updateBm.getAddress();
         this.valuationCap = updateBm.getValuationCap();
         this.goalInvestment = updateBm.getGoalInvestment();
         this.maxIssuedShare = updateBm.getMaxIssuedShare();
         this.deadline = updateBm.getDeadline();
-        this.longPitchUrl = updateBm.getLongPitchUrl();
+        this.longPitchURL = updateBm.getLongPitchURL();
     }
 
     public List<String> getSubCategories() {

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -30,7 +30,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Country country;
 
-    private String profileImg;
+    private String profileImgKey;
 
     @OneToMany(mappedBy = "member")
     private List<Investment> investments = new ArrayList<>();
@@ -44,10 +44,10 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<Comment> comments = new ArrayList<>();
 
-    public Member(String name, String email, Country country, String profileImg) {
+    public Member(String name, String email, Country country, String profileImgKey) {
         this.name = name;
         this.email = email;
         this.country = country;
-        this.profileImg = profileImg;
+        this.profileImgKey = profileImgKey;
     }
 }

--- a/src/main/java/com/pitchain/entity/PtImg.java
+++ b/src/main/java/com/pitchain/entity/PtImg.java
@@ -22,11 +22,11 @@ public class PtImg {
     private int serialNum;
 
     @Column(nullable = false)
-    private String img;
+    private String imgKey;
 
-    public PtImg(Bm bm, int serialNum, String img) {
+    public PtImg(Bm bm, int serialNum, String imgKey) {
         this.bm = bm;
         this.serialNum = serialNum;
-        this.img = img;
+        this.imgKey = imgKey;
     }
 }

--- a/src/main/java/com/pitchain/entity/Sp.java
+++ b/src/main/java/com/pitchain/entity/Sp.java
@@ -21,20 +21,20 @@ public class Sp extends BaseEntity {
     private Bm bm;
 
     @Column(nullable = false)
-    private String shortPitchURL;
+    private String spKey;
 
     @Column(nullable = false)
-    private String thumbnailImg;
+    private String thumbnailImgKey;
 
     private int views;
 
     @Column(nullable = false)
     private String name;
 
-    public Sp(Bm bm, String shortPitchURL, String thumbnailImg, String name) {
+    public Sp(Bm bm, String spKey, String thumbnailImgKey, String name) {
         this.bm = bm;
-        this.shortPitchURL = shortPitchURL;
-        this.thumbnailImg = thumbnailImg;
+        this.spKey = spKey;
+        this.thumbnailImgKey = thumbnailImgKey;
         this.name = name;
         this.views = 0;
     }
@@ -44,8 +44,8 @@ public class Sp extends BaseEntity {
     }
 
     public void update(Sp updateSp) {
-        this.shortPitchURL = updateSp.shortPitchURL;
-        this.thumbnailImg = updateSp.thumbnailImg;
+        this.spKey = updateSp.spKey;
+        this.thumbnailImgKey = updateSp.thumbnailImgKey;
         this.name = updateSp.name;
     }
 }

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -23,6 +23,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.pitchain.service.S3Service.getFileURL;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -32,12 +34,12 @@ public class BmService {
     private final MyBmRepository myBmRepository;
     private final S3Service s3Service;
 
-    public void createBm(Long memberId, CreateBmReq createBmReq, MultipartFile logoImg, MultipartFile descriptionImg) {
+    public void createBm(Long memberId, CreateBmReq createBmReq, MultipartFile logoImg, MultipartFile descImg) {
         Member member = entityFacade.getMember(memberId);
-        String logoImgURL = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
-        String descriptionImgURL = s3Service.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+        String logoImgKey = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descImgKey = s3Service.uploadFile(descImg, S3UploadTarget.COMPANY_DESC);
 
-        Bm newBm = createBmReq.createBm(member, logoImgURL, descriptionImgURL);
+        Bm newBm = createBmReq.createBm(member, logoImgKey, descImgKey);
         newBm.addSubCategories(createBmReq.subCategories());
 
         bmRepository.save(newBm);
@@ -49,32 +51,30 @@ public class BmService {
 
         BmWithLikeDto bmWithLikeDto = bmRepository.getBmWithLikeDto(member.getId(), bmId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.BM_NOT_FOUND));
+        Bm bm = bmWithLikeDto.getBm();
 
-        List<PtImg> ptImgs = bmRepository.getPtImgsByBmId(bmWithLikeDto.getBm().getId());
-        List<PtImgRes> ptImgResList = ptImgs.stream()
-                .map(PtImgRes::createRes)
-                .toList();
+        long likeCnt = myBmRepository.countByBm(bm);
+        List<PtImgRes> ptImgResList = getPtImgResList(bmId);
+        List<String> subCategories = bm.getSubCategories();
 
-        long likeCnt = myBmRepository.countByBm(bmWithLikeDto.getBm());
+        String spURL = getFileURL(bm.getSpKey());
+        String logoImgURL = getFileURL(bm.getLogoImgKey());
+        String descImgURL = getFileURL(bm.getDescImgKey());
 
-        List<String> subCategories = bmRepository.getSubCategoriesByBmId(bmId).stream()
-                .map(SubCategory::getKoreanName)
-                .toList();
-
-        return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList, subCategories);
+        return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList, subCategories, spURL, logoImgURL, descImgURL);
     }
 
-    public void updateBm(Long memberId, Long bmId, UpdateBmReq updateBmReq, MultipartFile logoImg, MultipartFile descriptionImg) {
+    public void updateBm(Long memberId, Long bmId, UpdateBmReq updateBmReq, MultipartFile logoImg, MultipartFile descImg) {
         Member member = entityFacade.getMember(memberId);
         Bm bm = entityFacade.getBm(bmId);
 
         validateBmOwner(bm, member);
 
-        String logoImgURL = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
-        String descriptionImgURL = s3Service.uploadFile(descriptionImg, S3UploadTarget.COMPANY_DESC);
+        String logoImgKey = s3Service.uploadFile(logoImg, S3UploadTarget.COMPANY_LOGO);
+        String descImgKey = s3Service.uploadFile(descImg, S3UploadTarget.COMPANY_DESC);
 
         bm.updateSubCategories(updateBmReq.subCategories());
-        Bm updateBm = updateBmReq.createBm(logoImgURL, descriptionImgURL);
+        Bm updateBm = updateBmReq.createBm(logoImgKey, descImgKey);
         bm.update(updateBm);
     }
 
@@ -100,17 +100,25 @@ public class BmService {
         bmRepository.delete(bm);
     }
 
+    private List<PtImgRes> getPtImgResList(Long bmId) {
+        List<PtImg> ptImgs = bmRepository.getPtImgsByBmId(bmId);
+        List<PtImgRes> ptImgResList = ptImgs.stream()
+                .map(ptImg -> PtImgRes.createRes(ptImg.getSerialNum(),
+                        getFileURL(ptImg.getImgKey())))
+                .toList();
+        return ptImgResList;
+    }
+
     private void deletePtImgs(Bm bm) {
         List<PtImg> ptImgs = bm.getPtImgs();
-        System.out.println("ptImgs = " + ptImgs);
-        ptImgs.forEach(pi -> s3Service.deleteFile(pi.getImg()));
+        ptImgs.forEach(pi -> s3Service.deleteFile(pi.getImgKey()));
     }
 
     private List<PtImg> uploadPtImgs(List<MultipartFile> ptImgs, Bm bm) {
         List<PtImg> uploadPtImgs = new ArrayList<>();
         for (int serialNum = 0; ptImgs != null && serialNum < ptImgs.size(); serialNum++) {
-            String uploadFileURL = s3Service.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
-            PtImg ptImg = new PtImg(bm, serialNum, uploadFileURL);
+            String uploadFileKey = s3Service.uploadFile(ptImgs.get(serialNum), S3UploadTarget.COMPANY_PT);
+            PtImg ptImg = new PtImg(bm, serialNum, uploadFileKey);
             uploadPtImgs.add(ptImg);
         }
         return uploadPtImgs;

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -22,8 +22,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.pitchain.service.S3Service.getFileURL;
-
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -56,9 +54,9 @@ public class BmService {
         List<PtImgRes> ptImgResList = getPtImgResList(bmId);
         List<String> subCategories = bm.getSubCategories();
 
-        String spURL = getFileURL(bm.getSpKey());
-        String logoImgURL = getFileURL(bm.getLogoImgKey());
-        String descImgURL = getFileURL(bm.getDescImgKey());
+        String spURL = s3Service.getFileURL(bm.getSpKey());
+        String logoImgURL = s3Service.getFileURL(bm.getLogoImgKey());
+        String descImgURL = s3Service.getFileURL(bm.getDescImgKey());
 
         return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList, subCategories, spURL, logoImgURL, descImgURL);
     }
@@ -103,7 +101,7 @@ public class BmService {
         List<PtImg> ptImgs = bmRepository.getPtImgsByBmId(bmId);
         List<PtImgRes> ptImgResList = ptImgs.stream()
                 .map(ptImg -> PtImgRes.createRes(ptImg.getSerialNum(),
-                        getFileURL(ptImg.getImgKey())))
+                        s3Service.getFileURL(ptImg.getImgKey())))
                 .toList();
         return ptImgResList;
     }

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -2,7 +2,6 @@ package com.pitchain.service;
 
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.constant.S3UploadTarget;
-import com.pitchain.common.constant.SubCategory;
 import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.dto.BmWithLikeDto;
 import com.pitchain.dto.req.CreateBmReq;
@@ -111,7 +110,7 @@ public class BmService {
 
     private void deletePtImgs(Bm bm) {
         List<PtImg> ptImgs = bm.getPtImgs();
-        ptImgs.forEach(pi -> s3Service.deleteFile(pi.getImgKey()));
+        ptImgs.forEach(pi -> s3Service.deleteImg(pi.getImgKey()));
     }
 
     private List<PtImg> uploadPtImgs(List<MultipartFile> ptImgs, Bm bm) {

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -16,6 +16,7 @@ import com.pitchain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import static com.pitchain.service.S3Service.getFileURL;
 
 import java.util.List;
 
@@ -77,11 +78,16 @@ public class CommentService {
 
         return comments.stream()
                 .map(comment -> {
-                    List<ReplyCommentRes> replyCommentResList = comment.getChildComments().stream().map(ReplyCommentRes::createRes).toList();
+                    List<ReplyCommentRes> replyCommentResList = comment.getChildComments().stream()
+                            .map(childComment -> ReplyCommentRes.createRes(
+                                    childComment, getFileURL(childComment.getMember().getProfileImgKey())
+                            ))
+                            .toList();
+
                     if (comment.isDelYN()) {
                         return DeletedCommentRes.createRes(comment, replyCommentResList);
                     }
-                    return CommentRes.createRes(comment, replyCommentResList);
+                    return CommentRes.createRes(comment, replyCommentResList, getFileURL(comment.getMember().getProfileImgKey()));
                 })
                 .toList();
     }

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -16,7 +16,6 @@ import com.pitchain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import static com.pitchain.service.S3Service.getFileURL;
 
 import java.util.List;
 
@@ -27,6 +26,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final BmRepository bmRepository;
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void addComment(Long bmId, Long memberId, CommentDto.AddCommentDto dto) {
@@ -80,14 +80,14 @@ public class CommentService {
                 .map(comment -> {
                     List<ReplyCommentRes> replyCommentResList = comment.getChildComments().stream()
                             .map(childComment -> ReplyCommentRes.createRes(
-                                    childComment, getFileURL(childComment.getMember().getProfileImgKey())
+                                    childComment, s3Service.getFileURL(childComment.getMember().getProfileImgKey())
                             ))
                             .toList();
 
                     if (comment.isDelYN()) {
                         return DeletedCommentRes.createRes(comment, replyCommentResList);
                     }
-                    return CommentRes.createRes(comment, replyCommentResList, getFileURL(comment.getMember().getProfileImgKey()));
+                    return CommentRes.createRes(comment, replyCommentResList, s3Service.getFileURL(comment.getMember().getProfileImgKey()));
                 })
                 .toList();
     }

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -1,6 +1,5 @@
 package com.pitchain.service;
 
-
 import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.constant.S3UploadTarget;
 import com.pitchain.common.exception.GeneralHandler;
@@ -17,7 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.UUID;
 
 @Slf4j
@@ -30,21 +28,30 @@ public class S3Service {
     private String imageBucket;
     @Value("${spring.cloud.aws.s3.bucket.video}")
     private String videoBucket;
+    @Value("${spring.cloud.aws.s3.cdn}")
+    private static String cdnDomain;
 
     public String uploadFile(MultipartFile file, S3UploadTarget target) {
-        String fileURL = Strings.EMPTY;
+        String fileKey = Strings.EMPTY;
         if (file == null || file.isEmpty())
-            return fileURL;
+            return fileKey;
 
         try {
             validateMimeType(file, target);
-            fileURL = upload(file, target);
+            fileKey = upload(file, target);
         } catch (IOException e) {
             throw new GeneralHandler(ErrorStatus.FAIL_STREAM_CONVERT);
         } catch (S3Exception e) {
             throw new GeneralHandler(ErrorStatus.FAIL_S3_UPLOAD);
         }
-        return fileURL;
+        return fileKey;
+    }
+
+    public static String getFileURL(String fileName) {
+        if (fileName == null) {
+            return Strings.EMPTY;
+        }
+        return cdnDomain + "/" + fileName;
     }
 
     private static void validateMimeType(MultipartFile file, S3UploadTarget target) {
@@ -54,10 +61,10 @@ public class S3Service {
     }
 
     private String upload(MultipartFile file, S3UploadTarget target) throws IOException {
-        String fileName = UUID.randomUUID().toString();
-        String uploadFileUrl = putS3(file, fileName, target);
+        String fileName = UUID.randomUUID() + file.getOriginalFilename();
+        String fileKey = putS3(file, fileName, target);
 
-        return uploadFileUrl;
+        return fileKey;
     }
 
     private String putS3(MultipartFile file, String fileName, S3UploadTarget target) throws IOException {
@@ -73,7 +80,7 @@ public class S3Service {
                         .build()
         );
 
-        return uploadFile.getURL().toString();
+        return uploadFile.getFilename();  //key
     }
 
     private String getTargetBucket(S3UploadTarget target) {
@@ -83,23 +90,11 @@ public class S3Service {
         };
     }
 
-    public void deleteFile(String fileURL) {
+    public void deleteFile(String fileKey) {
         try {
-            URI uri = URI.create(fileURL);
-            String bucketName = extractBucketName(uri);
-            String bucketKey = extractBucketKey(uri);
-            s3Operations.deleteObject(bucketName, bucketKey);
+            s3Operations.deleteObject(imageBucket, fileKey);
         } catch (Exception e) {
             throw new GeneralHandler(ErrorStatus.INVALID_BUCKET_URL);
         }
-    }
-
-    public String extractBucketName(URI uri) {
-        String host = uri.getHost();
-        return host.split("\\.")[0];
-    }
-
-    public String extractBucketKey(URI uri) {
-        return uri.getPath().substring(1);
     }
 }

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -28,7 +28,6 @@ public class S3Service {
     private String imageBucket;
     @Value("${spring.cloud.aws.s3.bucket.video}")
     private String videoBucket;
-    @Value("${spring.cloud.aws.s3.cdn}")
     private static String cdnDomain;
 
     public String uploadFile(MultipartFile file, S3UploadTarget target) {
@@ -83,6 +82,22 @@ public class S3Service {
         return uploadFile.getFilename();  //key
     }
 
+    public void deleteImg(String fileKey) {
+        deleteFile(imageBucket, fileKey);
+    }
+
+    public void deleteVid(String fileKey) {
+        deleteFile(videoBucket, fileKey);
+    }
+
+    private void deleteFile(String bucket, String fileKey) {
+        try {
+            s3Operations.deleteObject(bucket, fileKey);
+        } catch (Exception e) {
+            throw new GeneralHandler(ErrorStatus.INVALID_BUCKET_URL);
+        }
+    }
+
     private String getTargetBucket(S3UploadTarget target) {
         return switch (target.getMime()) {
             case IMAGE -> imageBucket;
@@ -90,11 +105,8 @@ public class S3Service {
         };
     }
 
-    public void deleteFile(String fileKey) {
-        try {
-            s3Operations.deleteObject(imageBucket, fileKey);
-        } catch (Exception e) {
-            throw new GeneralHandler(ErrorStatus.INVALID_BUCKET_URL);
-        }
+    @Value("${spring.cloud.aws.s3.cdn}")
+    private void setCdnDomain(String cdnDomain) {
+        this.cdnDomain = cdnDomain;
     }
 }

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -50,7 +50,7 @@ public class S3Service {
         if (fileKey == null) {
             return Strings.EMPTY;
         }
-        return cdnDomain + "/" + fileKey;
+        return getCdnDomain() + "/" + fileKey;
     }
 
     private static void validateMimeType(MultipartFile file, S3UploadTarget target) {
@@ -108,5 +108,9 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.cdn}")
     private void setCdnDomain(String cdnDomain) {
         this.cdnDomain = cdnDomain;
+    }
+
+    private static String getCdnDomain() {
+        return cdnDomain;
     }
 }

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -47,11 +47,11 @@ public class S3Service {
         return fileKey;
     }
 
-    public static String getFileURL(String fileName) {
-        if (fileName == null) {
+    public static String getFileURL(String fileKey) {
+        if (fileKey == null) {
             return Strings.EMPTY;
         }
-        return cdnDomain + "/" + fileName;
+        return cdnDomain + "/" + fileKey;
     }
 
     private static void validateMimeType(MultipartFile file, S3UploadTarget target) {

--- a/src/main/java/com/pitchain/service/S3Service.java
+++ b/src/main/java/com/pitchain/service/S3Service.java
@@ -28,7 +28,8 @@ public class S3Service {
     private String imageBucket;
     @Value("${spring.cloud.aws.s3.bucket.video}")
     private String videoBucket;
-    private static String cdnDomain;
+    @Value("${spring.cloud.aws.s3.cdn}")
+    private String cdnDomain;
 
     public String uploadFile(MultipartFile file, S3UploadTarget target) {
         String fileKey = Strings.EMPTY;
@@ -46,11 +47,11 @@ public class S3Service {
         return fileKey;
     }
 
-    public static String getFileURL(String fileKey) {
+    public String getFileURL(String fileKey) {
         if (fileKey == null) {
             return Strings.EMPTY;
         }
-        return getCdnDomain() + "/" + fileKey;
+        return cdnDomain + "/" + fileKey;
     }
 
     private static void validateMimeType(MultipartFile file, S3UploadTarget target) {
@@ -103,14 +104,5 @@ public class S3Service {
             case IMAGE -> imageBucket;
             case VIDEO -> videoBucket;
         };
-    }
-
-    @Value("${spring.cloud.aws.s3.cdn}")
-    private void setCdnDomain(String cdnDomain) {
-        this.cdnDomain = cdnDomain;
-    }
-
-    private static String getCdnDomain() {
-        return cdnDomain;
     }
 }

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -19,6 +19,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+import static com.pitchain.service.S3Service.getFileURL;
+
 @Transactional
 @RequiredArgsConstructor
 @Service
@@ -32,10 +34,14 @@ public class SpService {
         Member member = entityFacade.getMember(memberId);
         Bm bm = entityFacade.getBm(createSpReq.bmId());
 
-        String spVidURL = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
-        String thumbnailImgURL = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
+        String spOriginKey = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
 
-        Sp sp = new Sp(bm, spVidURL, thumbnailImgURL, createSpReq.name());
+        //TO DO - AWS Lambda에서 정상적으로 트랜스코딩 완료됐으면 여기로 알려주기
+
+        String spKey = createSpM3U8Key(spOriginKey);
+        String thumbnailImgKey = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
+
+        Sp sp = new Sp(bm, spKey, thumbnailImgKey, createSpReq.name());
         spRepository.save(sp);
     }
 
@@ -46,10 +52,15 @@ public class SpService {
         return spWithLikeDtos.stream()
                 .map(spWithLikeDto -> {
                     Sp sp = spWithLikeDto.getSp();
+                    String spURL = getFileURL(sp.getSpKey());
+                    String thumbnailImgURL = getFileURL(sp.getThumbnailImgKey());
+
                     Bm bm = sp.getBm();
                     long likeCnt = myBmRepository.countByBm(bm);
                     List<String> subCategories = bm.getSubCategories();
-                    return SpDetailRes.createRes(spWithLikeDto, likeCnt, subCategories);
+
+                    String logoImgURL = getFileURL(bm.getLogoImgKey());
+                    return SpDetailRes.createRes(spWithLikeDto, spURL,thumbnailImgURL, likeCnt, subCategories, logoImgURL);
                 })
                 .toList();
     }
@@ -58,11 +69,16 @@ public class SpService {
     public SpDetailRes getSpDetail(Long memberId, Long spId) {
         SpWithLikeDto spWithLikeDto = spRepository.findSpWithLike(memberId, spId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND));
-        Bm bm = spWithLikeDto.getSp().getBm();
+        Sp sp = spWithLikeDto.getSp();
+        String spURL = getFileURL(sp.getSpKey());
+        String thumbnailImgURL = getFileURL(sp.getThumbnailImgKey());
+        Bm bm = sp.getBm();
         long likeCnt = myBmRepository.countByBm(bm);
         List<String> subCategories = bm.getSubCategories();
+        String logoImgURL = getFileURL(bm.getLogoImgKey());
 
-        return SpDetailRes.createRes(spWithLikeDto, likeCnt, subCategories);
+
+        return SpDetailRes.createRes(spWithLikeDto, spURL, thumbnailImgURL, likeCnt, subCategories, logoImgURL);
     }
 
     public void updateSp(Long memberId, Long spId, String name, MultipartFile spVid, MultipartFile thumbnailImg) {
@@ -71,13 +87,13 @@ public class SpService {
 
         validateSpOwner(sp, member);
 
-        s3Service.deleteFile(sp.getShortPitchURL());
-        s3Service.deleteFile(sp.getThumbnailImg());
+        s3Service.deleteFile(sp.getSpKey());
+        s3Service.deleteFile(sp.getThumbnailImgKey());
 
-        String spVidURL = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
-        String thumbnailImgURL = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
+        String spKey = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
+        String thumbnailImgKey = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);
 
-        Sp updateSp = new Sp(sp.getBm(), spVidURL, thumbnailImgURL, name);
+        Sp updateSp = new Sp(sp.getBm(), spKey, thumbnailImgKey, name);
         sp.update(updateSp);
     }
 
@@ -94,5 +110,14 @@ public class SpService {
         if (!sp.isOwner(member.getId())) {
             throw new GeneralHandler(ErrorStatus.MEMBER_FORBIDDEN);
         }
+    }
+
+    private String createSpM3U8Key(String spKey) {
+        String removedFileKey = removeFileExtension(spKey);
+        return removedFileKey + ".m3u8";
+    }
+
+    public String removeFileExtension(String originalFileName) {
+        return originalFileName.split("\\.")[0];
     }
 }

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -72,11 +72,11 @@ public class SpService {
         Sp sp = spWithLikeDto.getSp();
         String spURL = getFileURL(sp.getSpKey());
         String thumbnailImgURL = getFileURL(sp.getThumbnailImgKey());
+
         Bm bm = sp.getBm();
         long likeCnt = myBmRepository.countByBm(bm);
         List<String> subCategories = bm.getSubCategories();
         String logoImgURL = getFileURL(bm.getLogoImgKey());
-
 
         return SpDetailRes.createRes(spWithLikeDto, spURL, thumbnailImgURL, likeCnt, subCategories, logoImgURL);
     }
@@ -87,8 +87,8 @@ public class SpService {
 
         validateSpOwner(sp, member);
 
-        s3Service.deleteFile(sp.getSpKey());
-        s3Service.deleteFile(sp.getThumbnailImgKey());
+        s3Service.deleteVid(sp.getSpKey());
+        s3Service.deleteImg(sp.getThumbnailImgKey());
 
         String spKey = s3Service.uploadFile(spVid, S3UploadTarget.COMPANY_VIDEO);
         String thumbnailImgKey = s3Service.uploadFile(thumbnailImg, S3UploadTarget.COMPANY_THUMBNAIL);

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -19,8 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static com.pitchain.service.S3Service.getFileURL;
-
 @Transactional
 @RequiredArgsConstructor
 @Service
@@ -52,14 +50,14 @@ public class SpService {
         return spWithLikeDtos.stream()
                 .map(spWithLikeDto -> {
                     Sp sp = spWithLikeDto.getSp();
-                    String spURL = getFileURL(sp.getSpKey());
-                    String thumbnailImgURL = getFileURL(sp.getThumbnailImgKey());
+                    String spURL = s3Service.getFileURL(sp.getSpKey());
+                    String thumbnailImgURL = s3Service.getFileURL(sp.getThumbnailImgKey());
 
                     Bm bm = sp.getBm();
                     long likeCnt = myBmRepository.countByBm(bm);
                     List<String> subCategories = bm.getSubCategories();
 
-                    String logoImgURL = getFileURL(bm.getLogoImgKey());
+                    String logoImgURL = s3Service.getFileURL(bm.getLogoImgKey());
                     return SpDetailRes.createRes(spWithLikeDto, spURL,thumbnailImgURL, likeCnt, subCategories, logoImgURL);
                 })
                 .toList();
@@ -70,13 +68,13 @@ public class SpService {
         SpWithLikeDto spWithLikeDto = spRepository.findSpWithLike(memberId, spId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.SP_NOT_FOUND));
         Sp sp = spWithLikeDto.getSp();
-        String spURL = getFileURL(sp.getSpKey());
-        String thumbnailImgURL = getFileURL(sp.getThumbnailImgKey());
+        String spURL = s3Service.getFileURL(sp.getSpKey());
+        String thumbnailImgURL = s3Service.getFileURL(sp.getThumbnailImgKey());
 
         Bm bm = sp.getBm();
         long likeCnt = myBmRepository.countByBm(bm);
         List<String> subCategories = bm.getSubCategories();
-        String logoImgURL = getFileURL(bm.getLogoImgKey());
+        String logoImgURL = s3Service.getFileURL(bm.getLogoImgKey());
 
         return SpDetailRes.createRes(spWithLikeDto, spURL, thumbnailImgURL, likeCnt, subCategories, logoImgURL);
     }

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 @Transactional
 @SpringBootTest
+@ActiveProfiles("dev-profile")
 class BmServiceTest {
     @MockBean
     private S3Service s3Service;
@@ -49,28 +51,28 @@ class BmServiceTest {
     private static final MainCategory MAIN_CATEGORY = MainCategory.FOOD;
     private static final List<SubCategory> SUB_CATEGORIES = List.of(SubCategory.BEVERAGE_COFFEE, SubCategory.ALCOHOL);
     private static final String COMPANY = "bm_company";
-    private static final String LOGO_IMG_URL = "bm_logo_img_url";
+    private static final String LOGO_IMG_KEY = "bm_logo_img_key";
     private static final String INTRO = "bm_intro";
     private static final String DESCRIPTION = "bm_description";
-    private static final String DESCRIPTION_IMG_URL = "bm_description_img_url";
+    private static final String DESC_IMG_KEY = "bm_desc_img_key";
     private static final String ADDRESS = "bm_address";
     private static final Long VALUATION_CAP = 100000L;
     private static final Long GOAL_INVESTMENT = 200000L;
     private static final Integer MAX_ISSUED_SHARE = 1000;
     private static final LocalDate DEADLINE = LocalDate.now();
-    private static final String LONG_PITCH_URL = "bm_longPitchUrl";
+    private static final String LONG_PITCH_URL = "bm_long_pitch_url";
 
     private static final MockMultipartFile LOGO_IMG = new MockMultipartFile(
             "logo", "logo.png", "image/png", "test data 1".getBytes());
-    private static final MockMultipartFile DESCRIPTION_IMG = new MockMultipartFile(
+    private static final MockMultipartFile DESC_IMG = new MockMultipartFile(
             "description", "description.png", "image/png", "test data 2".getBytes());
 
     private Member saveMember() {
         return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
     }
     private Bm saveBm(Member member) {
-        return bmRepository.save(new Bm(member, NAME, MAIN_CATEGORY, COMPANY, LOGO_IMG_URL,
-                INTRO, DESCRIPTION, DESCRIPTION_IMG_URL, ADDRESS, VALUATION_CAP,
+        return bmRepository.save(new Bm(member, NAME, MAIN_CATEGORY, COMPANY, LOGO_IMG_KEY,
+                INTRO, DESCRIPTION, DESC_IMG_KEY, ADDRESS, VALUATION_CAP,
                 GOAL_INVESTMENT, MAX_ISSUED_SHARE, DEADLINE, LONG_PITCH_URL));
     }
     private List<PtImg> createPtImgs(Bm bm) {
@@ -89,12 +91,12 @@ class BmServiceTest {
                 INTRO, DESCRIPTION, ADDRESS, VALUATION_CAP, GOAL_INVESTMENT, MAX_ISSUED_SHARE, DEADLINE, LONG_PITCH_URL);
 
         when(s3Service.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
-                .thenReturn(LOGO_IMG_URL);
-        when(s3Service.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
-                .thenReturn(DESCRIPTION_IMG_URL);
+                .thenReturn(LOGO_IMG_KEY);
+        when(s3Service.uploadFile(DESC_IMG, S3UploadTarget.COMPANY_DESC))
+                .thenReturn(DESC_IMG_KEY);
 
         //when
-        bmService.createBm(member.getId(), createBmReq, LOGO_IMG, DESCRIPTION_IMG);
+        bmService.createBm(member.getId(), createBmReq, LOGO_IMG, DESC_IMG);
 
         //then
         List<Bm> all = bmRepository.findAll();
@@ -104,16 +106,16 @@ class BmServiceTest {
         assertThat(bm.getMainCategory()).isEqualTo(MAIN_CATEGORY);
         assertThat(bm.getSubCategories()).isEqualTo(SUB_CATEGORIES.stream().map(SubCategory::getKoreanName).toList());
         assertThat(bm.getCompany()).isEqualTo(COMPANY);
-        assertThat(bm.getLogoImg()).isEqualTo(LOGO_IMG_URL);
+        assertThat(bm.getLogoImgKey()).isEqualTo(LOGO_IMG_KEY);
         assertThat(bm.getIntro()).isEqualTo(INTRO);
         assertThat(bm.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(bm.getDescriptionImg()).isEqualTo(DESCRIPTION_IMG_URL);
+        assertThat(bm.getDescImgKey()).isEqualTo(DESC_IMG_KEY);
         assertThat(bm.getAddress()).isEqualTo(ADDRESS);
         assertThat(bm.getValuationCap()).isEqualTo(VALUATION_CAP);
         assertThat(bm.getGoalInvestment()).isEqualTo(GOAL_INVESTMENT);
         assertThat(bm.getMaxIssuedShare()).isEqualTo(MAX_ISSUED_SHARE);
         assertThat(bm.getDeadline()).isEqualTo(DEADLINE);
-        assertThat(bm.getLongPitchUrl()).isEqualTo(LONG_PITCH_URL);
+        assertThat(bm.getLongPitchURL()).isEqualTo(LONG_PITCH_URL);
     }
 
     @Test
@@ -127,7 +129,10 @@ class BmServiceTest {
 
         List<PtImg> ptImgs = createPtImgs(bm);
         bm.updatePtImgs(ptImgs);
-        List<PtImgRes> ptImgResList = ptImgs.stream().map(PtImgRes::createRes).toList();
+        List<PtImgRes> ptImgResList = ptImgs.stream()
+                .map(ptImg -> PtImgRes.createRes(ptImg.getSerialNum(),
+                        s3Service.getFileURL(ptImg.getImgKey())))
+                .toList();
 
         //when
         BmDetailRes bmDetail = bmService.getBmDetail(member.getId(), bm.getId());
@@ -138,13 +143,13 @@ class BmServiceTest {
         assertThat(bmDetail.company()).isEqualTo(bm.getCompany());
         assertThat(bmDetail.intro()).isEqualTo(bm.getIntro());
         assertThat(bmDetail.mainCategory()).isEqualTo(bm.getMainCategory().getKoreanName());
-        assertThat(bmDetail.logoImg()).isEqualTo(bm.getLogoImg());
+        assertThat(bmDetail.logoImgURL()).isEqualTo(s3Service.getFileURL(bm.getLogoImgKey()));
         assertThat(bmDetail.description()).isEqualTo(bm.getDescription());
-        assertThat(bmDetail.descriptionImg()).isEqualTo(bm.getDescriptionImg());
+        assertThat(bmDetail.descImgURL()).isEqualTo(s3Service.getFileURL(bm.getDescImgKey()));
         assertThat(bmDetail.address()).isEqualTo(bm.getAddress());
         assertThat(bmDetail.createdAt()).isEqualTo(bm.getCreatedAt());
-        assertThat(bmDetail.longPitchUrl()).isEqualTo(bm.getLongPitchUrl());
-        assertThat(bmDetail.spURL()).isEqualTo(bm.getShortPitchURL());
+        assertThat(bmDetail.longPitchURL()).isEqualTo(bm.getLongPitchURL());
+        assertThat(bmDetail.spURL()).isEqualTo(s3Service.getFileURL(bm.getSpKey()));
         assertThat(bmDetail.isLiked()).isFalse();
         assertThat(bmDetail.likeCnt()).isEqualTo(0);
         assertThat(bmDetail.ptImgResList()).isEqualTo(ptImgResList);
@@ -165,7 +170,10 @@ class BmServiceTest {
 
         List<PtImg> ptImgs = createPtImgs(bm);
         bm.updatePtImgs(ptImgs);
-        List<PtImgRes> ptImgResList = ptImgs.stream().map(PtImgRes::createRes).toList();
+        List<PtImgRes> ptImgResList = ptImgs.stream()
+                .map(ptImg -> PtImgRes.createRes(ptImg.getSerialNum(),
+                        s3Service.getFileURL(ptImg.getImgKey())))
+                .toList();
 
         //when
         BmDetailRes bmDetail = bmService.getBmDetail(member_01.getId(), bm.getId());
@@ -176,13 +184,13 @@ class BmServiceTest {
         assertThat(bmDetail.company()).isEqualTo(bm.getCompany());
         assertThat(bmDetail.intro()).isEqualTo(bm.getIntro());
         assertThat(bmDetail.mainCategory()).isEqualTo(bm.getMainCategory().getKoreanName());
-        assertThat(bmDetail.logoImg()).isEqualTo(bm.getLogoImg());
+        assertThat(bmDetail.logoImgURL()).isEqualTo(s3Service.getFileURL(bm.getLogoImgKey()));
         assertThat(bmDetail.description()).isEqualTo(bm.getDescription());
-        assertThat(bmDetail.descriptionImg()).isEqualTo(bm.getDescriptionImg());
+        assertThat(bmDetail.descImgURL()).isEqualTo(s3Service.getFileURL(bm.getDescImgKey()));
         assertThat(bmDetail.address()).isEqualTo(bm.getAddress());
         assertThat(bmDetail.createdAt()).isEqualTo(bm.getCreatedAt());
-        assertThat(bmDetail.longPitchUrl()).isEqualTo(bm.getLongPitchUrl());
-        assertThat(bmDetail.spURL()).isEqualTo(bm.getShortPitchURL());
+        assertThat(bmDetail.longPitchURL()).isEqualTo(bm.getLongPitchURL());
+        assertThat(bmDetail.spURL()).isEqualTo(s3Service.getFileURL(bm.getSpKey()));
         assertThat(bmDetail.isLiked()).isTrue();
         assertThat(bmDetail.likeCnt()).isEqualTo(2);
         assertThat(bmDetail.ptImgResList()).isEqualTo(ptImgResList);
@@ -214,30 +222,30 @@ class BmServiceTest {
         final MainCategory updatedMainCategory = MainCategory.COMMUNICATION_SECURITY_DATA;
         final List<SubCategory> updatedSubCategories = List.of(SubCategory.DATA_ANALYTICS, SubCategory.CYBER_SECURITY);
         final String updatedCompany = "updated_bm_company";
-        final String updatedLogoImgUrl = "updated_bm_logo_img_url";
+        final String updatedLogoImgKey = "updated_bm_logo_img_key";
         final String updatedIntro = "updated_bm_intro";
         final String updatedDescription = "updated_bm_description";
-        final String updatedDescriptionImgUrl = "updated_bm_description_img_url";
+        final String updatedDescImgKey = "updated_bm_desc_img_key";
         final String updatedAddress = "updated_bm_address";
         final Long updatedValuationCap = 200000L;
         final Long updatedGoalInvestment = 2000L;
         final Integer updatedMaxIssuedShare = 2000;
         final LocalDate updatedDeadline = LocalDate.now().plusDays(30);
-        final String updatedLongPitchUrl = "updated_bm_longPitchUrl";
+        final String updatedLongPitchURL = "updated_bm_long_pitch_url";
 
         UpdateBmReq updateBmReq = new UpdateBmReq(updatedName, updatedMainCategory,
                 updatedSubCategories, updatedCompany, updatedIntro, updatedDescription,
                 updatedAddress, updatedValuationCap, updatedGoalInvestment,
-                updatedMaxIssuedShare, updatedDeadline, updatedLongPitchUrl
+                updatedMaxIssuedShare, updatedDeadline, updatedLongPitchURL
         );
 
         when(s3Service.uploadFile(LOGO_IMG, S3UploadTarget.COMPANY_LOGO))
-                .thenReturn(updatedLogoImgUrl);
-        when(s3Service.uploadFile(DESCRIPTION_IMG, S3UploadTarget.COMPANY_DESC))
-                .thenReturn(updatedDescriptionImgUrl);
+                .thenReturn(updatedLogoImgKey);
+        when(s3Service.uploadFile(DESC_IMG, S3UploadTarget.COMPANY_DESC))
+                .thenReturn(updatedDescImgKey);
 
         //when
-        bmService.updateBm(member.getId(), bm.getId(), updateBmReq, LOGO_IMG, DESCRIPTION_IMG);
+        bmService.updateBm(member.getId(), bm.getId(), updateBmReq, LOGO_IMG, DESC_IMG);
 
         //then
         Bm updatedBm = bmRepository.findById(bm.getId()).orElseThrow();
@@ -245,16 +253,16 @@ class BmServiceTest {
         assertThat(updatedBm.getMainCategory()).isEqualTo(updatedMainCategory);
         assertThat(updatedBm.getSubCategories()).isEqualTo(updatedSubCategories.stream().map(SubCategory::getKoreanName).toList());
         assertThat(updatedBm.getCompany()).isEqualTo(updatedCompany);
-        assertThat(updatedBm.getLogoImg()).isEqualTo(updatedLogoImgUrl);
+        assertThat(updatedBm.getLogoImgKey()).isEqualTo(updatedLogoImgKey);
         assertThat(updatedBm.getIntro()).isEqualTo(updatedIntro);
         assertThat(updatedBm.getDescription()).isEqualTo(updatedDescription);
-        assertThat(updatedBm.getDescriptionImg()).isEqualTo(updatedDescriptionImgUrl);
+        assertThat(updatedBm.getDescImgKey()).isEqualTo(updatedDescImgKey);
         assertThat(updatedBm.getAddress()).isEqualTo(updatedAddress);
         assertThat(updatedBm.getValuationCap()).isEqualTo(updatedValuationCap);
         assertThat(updatedBm.getGoalInvestment()).isEqualTo(updatedGoalInvestment);
         assertThat(updatedBm.getMaxIssuedShare()).isEqualTo(updatedMaxIssuedShare);
         assertThat(updatedBm.getDeadline()).isEqualTo(updatedDeadline);
-        assertThat(updatedBm.getLongPitchUrl()).isEqualTo(updatedLongPitchUrl);
+        assertThat(updatedBm.getLongPitchURL()).isEqualTo(updatedLongPitchURL);
     }
 
     @Test
@@ -274,7 +282,7 @@ class BmServiceTest {
         final Long UPDATED_GOAL_INVESTMENT = 2000L;
         final Integer UPDATED_MAX_ISSUED_SHARE = 2000;
         final LocalDate UPDATED_DEADLINE = LocalDate.now().plusDays(30);
-        final String UPDATED_LONG_PITCH_URL = "update_bm_longPitchUrl";
+        final String UPDATED_LONG_PITCH_URL = "updated_bm_long_pitch_url";
 
         UpdateBmReq updateBmReq = new UpdateBmReq(UPDATED_NAME, UPDATED_MAIN_CATEGORY,
                 UPDATED_SUB_CATEGORIES, UPDATED_COMPANY, UPDATED_INTRO, UPDATED_DESCRIPTION,
@@ -325,7 +333,7 @@ class BmServiceTest {
         for (int i = 0; i < ptImgs.size(); i++) {
             assertThat(updatedPtImgs.get(i).getSerialNum()).isEqualTo(i);
             assertThat(updatedPtImgs.get(i).getBm().getId()).isEqualTo(updatedBm.getId());
-            assertThat(updatedPtImgs.get(i).getImg()).isEqualTo("fake_" + (i + 1));
+            assertThat(updatedPtImgs.get(i).getImgKey()).isEqualTo("fake_" + (i + 1));
         }
     }
 
@@ -361,7 +369,7 @@ class BmServiceTest {
         for (int i = 0; i < updatePtImgs.size(); i++) {
             assertThat(updatedPtImgs.get(i).getSerialNum()).isEqualTo(i);
             assertThat(updatedPtImgs.get(i).getBm().getId()).isEqualTo(updatedBm.getId());
-            assertThat(updatedPtImgs.get(i).getImg()).isEqualTo("fake_" + (i + 1));
+            assertThat(updatedPtImgs.get(i).getImgKey()).isEqualTo("fake_" + (i + 1));
         }
     }
 

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -34,7 +33,6 @@ import static org.mockito.Mockito.when;
 
 @Transactional
 @SpringBootTest
-@ActiveProfiles("dev-profile")
 class BmServiceTest {
     @MockBean
     private S3Service s3Service;

--- a/src/test/java/com/pitchain/service/CommentServiceTest.java
+++ b/src/test/java/com/pitchain/service/CommentServiceTest.java
@@ -27,7 +27,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import static com.pitchain.service.S3Service.getFileURL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.transaction.annotation.Propagation.NEVER;
 
@@ -43,6 +42,8 @@ class CommentServiceTest {
     private CommentService commentService;
     @Autowired
     private CommentRepository commentRepository;
+    @Autowired
+    private S3Service s3Service;
 
     @AfterEach
     void tearDown() {
@@ -154,13 +155,13 @@ class CommentServiceTest {
         assertThat(foundComment.getCommentId()).isEqualTo(parentComment.getId());
         assertThat(foundComment.getWriterId()).isEqualTo(parentComment.getMember().getId());
         assertThat(foundComment.getContent()).isEqualTo(parentComment.getContent());
-        assertThat(foundComment.getWriterProfileImgURL()).isEqualTo(getFileURL(parentComment.getMember().getProfileImgKey()));
+        assertThat(foundComment.getWriterProfileImgURL()).isEqualTo(s3Service.getFileURL(parentComment.getMember().getProfileImgKey()));
 
         List<ReplyCommentRes> replyComments = foundComment.getReplyComments();
         ReplyCommentRes replyCommentRes = replyComments.get(0);
         assertThat(replyCommentRes.content()).isEqualTo(replyComment.getContent());
         assertThat(replyCommentRes.writerId()).isEqualTo(replyComment.getMember().getId());
-        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(getFileURL(replyComment.getMember().getProfileImgKey()));
+        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(s3Service.getFileURL(replyComment.getMember().getProfileImgKey()));
     }
 
     @Test
@@ -187,7 +188,7 @@ class CommentServiceTest {
         ReplyCommentRes replyCommentRes = deletedCommentRes.getReplyComments().get(0);
         assertThat(replyCommentRes.commentId()).isEqualTo(replyComment.getId());
         assertThat(replyCommentRes.writerId()).isEqualTo(replyComment.getMember().getId());
-        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(getFileURL(replyComment.getMember().getProfileImgKey()));
+        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(s3Service.getFileURL(replyComment.getMember().getProfileImgKey()));
     }
 
     @Test

--- a/src/test/java/com/pitchain/service/CommentServiceTest.java
+++ b/src/test/java/com/pitchain/service/CommentServiceTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import static com.pitchain.service.S3Service.getFileURL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.transaction.annotation.Propagation.NEVER;
 
@@ -141,10 +142,9 @@ class CommentServiceTest {
         Bm bm = saveBm(memberA);
 
         Comment parentComment = saveComment(memberA, bm);
-        String replyCommentContent = "답글 내용";
 
         Member memberB = saveMember();
-        commentRepository.save(new Comment(memberB, bm, parentComment, replyCommentContent));
+        Comment replyComment = saveReplyComment(memberB, parentComment, bm);
 
         //when
         List<? extends BaseCommentRes> comments = commentService.getComments(bm.getId());
@@ -152,13 +152,15 @@ class CommentServiceTest {
         //then
         CommentRes foundComment = (CommentRes) comments.get(0);
         assertThat(foundComment.getCommentId()).isEqualTo(parentComment.getId());
-        assertThat(foundComment.getWriterId()).isEqualTo(memberA.getId());
+        assertThat(foundComment.getWriterId()).isEqualTo(parentComment.getMember().getId());
         assertThat(foundComment.getContent()).isEqualTo(parentComment.getContent());
+        assertThat(foundComment.getWriterProfileImgURL()).isEqualTo(getFileURL(parentComment.getMember().getProfileImgKey()));
 
         List<ReplyCommentRes> replyComments = foundComment.getReplyComments();
         ReplyCommentRes replyCommentRes = replyComments.get(0);
-        assertThat(replyCommentRes.content()).isEqualTo(replyCommentContent);
-        assertThat(replyCommentRes.writerId()).isEqualTo(memberB.getId());
+        assertThat(replyCommentRes.content()).isEqualTo(replyComment.getContent());
+        assertThat(replyCommentRes.writerId()).isEqualTo(replyComment.getMember().getId());
+        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(getFileURL(replyComment.getMember().getProfileImgKey()));
     }
 
     @Test
@@ -173,8 +175,7 @@ class CommentServiceTest {
         commentRepository.save(parentComment);
 
         Member memberB = saveMember();
-        Comment comment = new Comment(memberB, bm, parentComment, "답글 내용");
-        Comment replyComment = commentRepository.save(comment);
+        Comment replyComment = saveReplyComment(memberB, parentComment, bm);
 
         //when
         List<? extends BaseCommentRes> comments = commentService.getComments(bm.getId());
@@ -186,6 +187,7 @@ class CommentServiceTest {
         ReplyCommentRes replyCommentRes = deletedCommentRes.getReplyComments().get(0);
         assertThat(replyCommentRes.commentId()).isEqualTo(replyComment.getId());
         assertThat(replyCommentRes.writerId()).isEqualTo(replyComment.getMember().getId());
+        assertThat(replyCommentRes.writerProfileImgURL()).isEqualTo(getFileURL(replyComment.getMember().getProfileImgKey()));
     }
 
     @Test
@@ -264,7 +266,7 @@ class CommentServiceTest {
         Comment parentComment = saveComment(memberA, bm);
 
         Member memberB = saveMember();
-        commentRepository.save(new Comment(memberB, bm, parentComment, "답글 내용"));
+        saveReplyComment(memberB, parentComment, bm);
 
         //when
         commentService.removeComment(parentComment.getId(), memberA.getId());
@@ -298,7 +300,7 @@ class CommentServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg"));
+        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg.jpg"));
     }
 
     private Bm saveBm(Member member) {
@@ -309,5 +311,9 @@ class CommentServiceTest {
 
     private Comment saveComment(Member member, Bm bm) {
         return commentRepository.save(new Comment(member, bm, null, "댓글 내용"));
+    }
+
+    private Comment saveReplyComment(Member member, Comment parentComment, Bm bm) {
+        return commentRepository.save(new Comment(member, bm, parentComment, "답글 내용"));
     }
 }

--- a/src/test/java/com/pitchain/service/SpServiceTest.java
+++ b/src/test/java/com/pitchain/service/SpServiceTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import static com.pitchain.service.S3Service.getFileURL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -50,14 +51,14 @@ class SpServiceTest {
     }
 
     private Bm saveBm(Member member) {
-        return bmRepository.save(new Bm(member, "bm_name", MainCategory.FOOD,"bm_company", "bm_logo_img_url",
-                "bm_intro", "bm_description", "bm_description_img_url", "bm_address", 100000L,
-                1000L, 1000, LocalDate.now(), "bm_longPitchUrl"));
+        return bmRepository.save(new Bm(member, "bm_name", MainCategory.FOOD,"bm_company", "bm_logo_img_key",
+                "bm_intro", "bm_description", "bm_desc_img_key", "bm_address", 100000L,
+                1000L, 1000, LocalDate.now(), "bm_long_pitch_url"));
     }
 
     private Sp saveSp(Bm bm) {
         return spRepository.save(
-                new Sp(bm, SP_VID.getOriginalFilename(), THUMBNAIL_IMG.getOriginalFilename(), SP_NAME));
+                new Sp(bm, SP_KEY, THUMBNAIL_IMG.getOriginalFilename(), SP_NAME));
     }
 
     @BeforeEach
@@ -70,6 +71,7 @@ class SpServiceTest {
     private Bm bm;
 
     private static final String SP_NAME = "sp_name";
+    private static final String SP_KEY = "sp_vid.m3u8";
     private static final MockMultipartFile SP_VID = new MockMultipartFile(
             "sp_vid", "sp_vid.mp4", "video/mp4", "test data 1".getBytes());
     private static final MockMultipartFile THUMBNAIL_IMG = new MockMultipartFile(
@@ -93,8 +95,8 @@ class SpServiceTest {
         List<Sp> all = spRepository.findAll();
         Sp sp = all.get(0);
         assertThat(sp.getBm()).isEqualTo(bm);
-        assertThat(sp.getShortPitchURL()).isEqualTo(SP_VID.getOriginalFilename());
-        assertThat(sp.getThumbnailImg()).isEqualTo(THUMBNAIL_IMG.getOriginalFilename());
+        assertThat(sp.getSpKey()).isEqualTo(SP_KEY);
+        assertThat(sp.getThumbnailImgKey()).isEqualTo(THUMBNAIL_IMG.getOriginalFilename());
         assertThat(sp.getName()).isEqualTo(SP_NAME);
     }
 
@@ -111,11 +113,11 @@ class SpServiceTest {
 
         //then
         assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
-        assertThat(spDetail.shortPitchURL()).isEqualTo(sp.getShortPitchURL());
-        assertThat(spDetail.thumbnailImg()).isEqualTo(sp.getThumbnailImg());
+        assertThat(spDetail.spURL()).isEqualTo(getFileURL(sp.getSpKey()));
+        assertThat(spDetail.thumbnailImgURL()).isEqualTo(getFileURL(sp.getThumbnailImgKey()));
         assertThat(spDetail.views()).isEqualTo(sp.getViews());
         assertThat(spDetail.name()).isEqualTo(sp.getName());
-        assertThat(spDetail.logoImg()).isEqualTo(sp.getBm().getLogoImg());
+        assertThat(spDetail.logoImgURL()).isEqualTo(getFileURL(sp.getBm().getLogoImgKey()));
         assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
         assertThat(spDetail.subCategories()).isEqualTo(subCategories);
         assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());
@@ -139,11 +141,11 @@ class SpServiceTest {
 
         //then
         assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
-        assertThat(spDetail.shortPitchURL()).isEqualTo(sp.getShortPitchURL());
-        assertThat(spDetail.thumbnailImg()).isEqualTo(sp.getThumbnailImg());
+        assertThat(spDetail.spURL()).isEqualTo(getFileURL(sp.getSpKey()));
+        assertThat(spDetail.thumbnailImgURL()).isEqualTo(getFileURL(sp.getThumbnailImgKey()));
         assertThat(spDetail.views()).isEqualTo(sp.getViews());
         assertThat(spDetail.name()).isEqualTo(sp.getName());
-        assertThat(spDetail.logoImg()).isEqualTo(sp.getBm().getLogoImg());
+        assertThat(spDetail.logoImgURL()).isEqualTo(getFileURL(sp.getBm().getLogoImgKey()));
         assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
         assertThat(spDetail.subCategories()).isEqualTo(subCategories);
         assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());
@@ -197,8 +199,8 @@ class SpServiceTest {
         List<Sp> all = spRepository.findAll();
         Sp updatedSp = all.get(0);
         assertThat(updatedSp.getBm()).isEqualTo(bm);
-        assertThat(updatedSp.getShortPitchURL()).isEqualTo(newSpVid.getOriginalFilename());
-        assertThat(updatedSp.getThumbnailImg()).isEqualTo(newThumbnailImg.getOriginalFilename());
+        assertThat(updatedSp.getSpKey()).isEqualTo(newSpVid.getOriginalFilename());
+        assertThat(updatedSp.getThumbnailImgKey()).isEqualTo(newThumbnailImg.getOriginalFilename());
         assertThat(updatedSp.getName()).isEqualTo(newName);
     }
 

--- a/src/test/java/com/pitchain/service/SpServiceTest.java
+++ b/src/test/java/com/pitchain/service/SpServiceTest.java
@@ -24,7 +24,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import static com.pitchain.service.S3Service.getFileURL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -113,11 +112,11 @@ class SpServiceTest {
 
         //then
         assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
-        assertThat(spDetail.spURL()).isEqualTo(getFileURL(sp.getSpKey()));
-        assertThat(spDetail.thumbnailImgURL()).isEqualTo(getFileURL(sp.getThumbnailImgKey()));
+        assertThat(spDetail.spURL()).isEqualTo(s3Service.getFileURL(sp.getSpKey()));
+        assertThat(spDetail.thumbnailImgURL()).isEqualTo(s3Service.getFileURL(sp.getThumbnailImgKey()));
         assertThat(spDetail.views()).isEqualTo(sp.getViews());
         assertThat(spDetail.name()).isEqualTo(sp.getName());
-        assertThat(spDetail.logoImgURL()).isEqualTo(getFileURL(sp.getBm().getLogoImgKey()));
+        assertThat(spDetail.logoImgURL()).isEqualTo(s3Service.getFileURL(sp.getBm().getLogoImgKey()));
         assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
         assertThat(spDetail.subCategories()).isEqualTo(subCategories);
         assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());
@@ -141,11 +140,11 @@ class SpServiceTest {
 
         //then
         assertThat(spDetail.bmId()).isEqualTo(sp.getBm().getId());
-        assertThat(spDetail.spURL()).isEqualTo(getFileURL(sp.getSpKey()));
-        assertThat(spDetail.thumbnailImgURL()).isEqualTo(getFileURL(sp.getThumbnailImgKey()));
+        assertThat(spDetail.spURL()).isEqualTo(s3Service.getFileURL(sp.getSpKey()));
+        assertThat(spDetail.thumbnailImgURL()).isEqualTo(s3Service.getFileURL(sp.getThumbnailImgKey()));
         assertThat(spDetail.views()).isEqualTo(sp.getViews());
         assertThat(spDetail.name()).isEqualTo(sp.getName());
-        assertThat(spDetail.logoImgURL()).isEqualTo(getFileURL(sp.getBm().getLogoImgKey()));
+        assertThat(spDetail.logoImgURL()).isEqualTo(s3Service.getFileURL(sp.getBm().getLogoImgKey()));
         assertThat(spDetail.mainCategory()).isEqualTo(sp.getBm().getMainCategory().getKoreanName());
         assertThat(spDetail.subCategories()).isEqualTo(subCategories);
         assertThat(spDetail.company()).isEqualTo(sp.getBm().getCompany());


### PR DESCRIPTION
## ⭐ Summary

> #92

<br>

## 📌 Tasks

- s3에 저장하는 파일에 대한 key/url 변수 구분
- url -> URL으로 통일
- s3에 있는 파일 key로 관리하기

<br>

## ETC

s3에 있는 객체 조회 시 cdn 주소로 프론트에 반환해야 하기 때문에 url로 저장하지 않고 버킷에 저장되는 파일의 key로 관리되도록 변경하였습니다. 추후에 유지 보수하는 것을 고려해도 key로 관리하는 것이 용이할 것 같습니다. 그래서 파라미터 개수가 늘어나거나 코드가 좀 길어진 부분이 있는데 이는 추후에 가독성 있게 리팩토링해야 할 것 같습니다.
