### PR TITLE
[refactor] JWT 토큰 에러 반환

### DIFF
--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
@@ -56,15 +56,6 @@ public enum ErrorStatus implements ResponseStatus {
                 .message(message)
                 .code(code)
                 .isSuccess(false)
-                .build();
-    }
-
-    @Override
-    public ResponseDTO getHttpStatusDto() {
-        return ResponseDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
                 .httpStatus(httpStatus)
                 .build();
     }

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ResponseStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ResponseStatus.java
@@ -6,6 +6,4 @@ public interface ResponseStatus {
 
     public ResponseDTO getDto();
 
-    public ResponseDTO getHttpStatusDto();
-
 }

--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/SuccessStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/SuccessStatus.java
@@ -22,15 +22,6 @@ public enum SuccessStatus implements ResponseStatus {
                 .message(message)
                 .code(code)
                 .isSuccess(true)
-                .build();
-    }
-
-    @Override
-    public ResponseDTO getHttpStatusDto() {
-        return ResponseDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(true)
                 .httpStatus(httpStatus)
                 .build();
     }

--- a/src/main/java/com/pitchain/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/pitchain/common/exception/ExceptionAdvice.java
@@ -77,8 +77,8 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = GeneralHandler.class)
     public ResponseEntity onThrowException(GeneralHandler generalHandler, HttpServletRequest request) {
         sendToSentry(generalHandler);
-        ResponseDTO errorHttpStatus = generalHandler.getErrorHttpStatus();
-        return handleExceptionInternal(generalHandler, errorHttpStatus, null, request);
+        ResponseDTO error = generalHandler.getError();
+        return handleExceptionInternal(generalHandler, error, null, request);
     }
 
     private static void sendToSentry(Exception e) {

--- a/src/main/java/com/pitchain/common/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/pitchain/common/exception/ExceptionHandlerFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 

--- a/src/main/java/com/pitchain/common/exception/GeneralHandler.java
+++ b/src/main/java/com/pitchain/common/exception/GeneralHandler.java
@@ -17,8 +17,4 @@ public class GeneralHandler extends RuntimeException {
     public ResponseDTO getError() {
         return this.errorStatus.getDto();
     }
-
-    public ResponseDTO getErrorHttpStatus() {
-        return this.errorStatus.getHttpStatusDto();
-    }
 }


### PR DESCRIPTION
## ⭐ Summary

> #110 

<br>

## 📌 Tasks

1. HttpStatus 유무에 따른 ResponseDto 생성 분리 제거 및 통합

<br>

## ETC

ResponseStatus 인터페이스에서 HttpStatus 유무에 따라 Dto 조회 메서드를 두개로 분리하셨더라고요(getDto() / getHttpStatusDto()) 따라서 GeneralHandler 에서도 (getError() / getErrorHttpStatus()) 이렇게 분리됩니다. 혹시 이렇게 분리하신 이유가 있나요? 

ExceptionHandlerFilter 에서
```
ResponseDTO error = generalHandler.getError();
response.setStatus(error.getHttpStatus().value());
```
이 getError()는 HttpStatus 값을 포함하지 않기 때문에 error.getHttpStatus() = null로 나와서 오류가 났습니다. 

통합해도 별 문제가 없어서 일단 이렇게 통합해봤는데, 혹시 분리하신 특별한 이유가 있는 거라면 다시 원래대로 돌리겠습니다!
원래대로 돌리면 

ExceptionHandlerFilter 에서
`ResponseDTO errorHttpStatus = generalHandler.getErrorHttpStatus();`
를 사용하면 해결됩니다.
