### PR TITLE
[feat] 서브 카테고리 입력 한글로 받기

### DIFF
--- a/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/pitchain/common/apiPayload/statusEnums/ErrorStatus.java
@@ -29,6 +29,9 @@ public enum ErrorStatus implements ResponseStatus {
     // bm
     BM_NOT_FOUND(HttpStatus.NOT_FOUND, "BM4041","존재하지 않는 BM입니다."),
 
+    // subCategory
+    SUB_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB_CATEGORY4041", "존재하지 않는 서브 카테고리입니다."),
+
     // sp
     SP_NOT_FOUND(HttpStatus.NOT_FOUND, "SP4041","존재하지 않는 SP입니다."),
 

--- a/src/main/java/com/pitchain/common/constant/SubCategory.java
+++ b/src/main/java/com/pitchain/common/constant/SubCategory.java
@@ -1,6 +1,10 @@
 package com.pitchain.common.constant;
 
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.exception.GeneralHandler;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 public enum SubCategory {
@@ -108,5 +112,12 @@ public enum SubCategory {
 
     public String getKoreanName() {
         return koreanName;
+    }
+
+    public static SubCategory from(String koreanName) {
+        return Arrays.stream(values())
+                .filter(val -> koreanName.equals(val.koreanName))
+                .findFirst()
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.SUB_CATEGORY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/pitchain/controller/BmPrefController.java
+++ b/src/main/java/com/pitchain/controller/BmPrefController.java
@@ -1,7 +1,6 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
-import com.pitchain.common.constant.SubCategory;
 import com.pitchain.service.BmPrefService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,8 +18,8 @@ public class BmPrefController {
 
     @PostMapping("/preferences")
     public CustomApiResponse createCategoryPref(@AuthenticationPrincipal Long memberId,
-                                                @RequestBody  List<SubCategory> subCategories) {
-        bmPrefService.createCategoryPref(memberId, subCategories);
+                                                @RequestBody List<String> subCategoriesInKorean) {
+        bmPrefService.createCategoryPref(memberId, subCategoriesInKorean);
         return CustomApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/pitchain/service/BmPrefService.java
+++ b/src/main/java/com/pitchain/service/BmPrefService.java
@@ -18,9 +18,13 @@ public class BmPrefService {
 
     private final MemberRepository memberRepository;
 
-    public void createCategoryPref(Long memberId, List<SubCategory> subCategories) {
+    public void createCategoryPref(Long memberId, List<String> subCategoriesInKorean) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<SubCategory> subCategories = subCategoriesInKorean.stream()
+                .map(SubCategory::from)
+                .toList();
 
         member.addCategoryPref(subCategories);
     }

--- a/src/test/java/com/pitchain/service/BmPrefServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmPrefServiceTest.java
@@ -1,11 +1,12 @@
 package com.pitchain.service;
 
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.constant.Country;
 import com.pitchain.common.constant.SubCategory;
+import com.pitchain.common.exception.GeneralHandler;
 import com.pitchain.entity.CategoryPref;
 import com.pitchain.entity.Member;
 import com.pitchain.repository.MemberRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -29,7 +33,7 @@ class BmPrefServiceTest {
     void 카테고리_선호_등록_성공() {
         //given
         Member member = saveMember();
-        List<SubCategory> subCategories = List.of(SubCategory.BEVERAGE_COFFEE, SubCategory.ALCOHOL);
+        List<String> subCategories = List.of(SubCategory.BEVERAGE_COFFEE.getKoreanName(), SubCategory.ALCOHOL.getKoreanName());
 
         //when
         bmPrefService.createCategoryPref(member.getId(), subCategories);
@@ -38,9 +42,23 @@ class BmPrefServiceTest {
         List<CategoryPref> categoryPrefs = member.getCategoryPrefs();
         for (int i = 0; i < subCategories.size(); i++) {
             SubCategory savedSubCategory = categoryPrefs.get(i).getSubCategory();
-            Assertions.assertThat(savedSubCategory).isEqualTo(subCategories.get(i));
+            assertThat(savedSubCategory.getKoreanName()).isEqualTo(subCategories.get(i));
         }
 
+    }
+
+    @Test
+    void 카테고리_선호_등록_실패() {
+        //given
+        Member member = saveMember();
+        String randomSubCategoryInKorean = "생맥주";
+        List<String> subCategories = List.of(SubCategory.BEVERAGE_COFFEE.getKoreanName(), randomSubCategoryInKorean);
+
+        //when
+        GeneralHandler error = assertThrows(GeneralHandler.class, () -> bmPrefService.createCategoryPref(member.getId(), subCategories));
+
+        //then
+        assertThat(error.getErrorStatus()).isEqualTo(ErrorStatus.SUB_CATEGORY_NOT_FOUND);
     }
 
     private Member saveMember() {


### PR DESCRIPTION
## ⭐ Summary

> #112 

<br>

## 📌 Tasks

1. 서브 카테고리 입력 한글로 받기

<br>

## ETC
Enum을 전부 한글로 바꿀 수도 있지만 일단 기존 Enum을 유지하고 영어로 변환하는 로직을 넣었습니다. 

