### PR TITLE
[fix] BM 상세 조회에서 MyBmHistory 저장 로직 수정

### DIFF
--- a/src/main/java/com/pitchain/entity/MyBmHistory.java
+++ b/src/main/java/com/pitchain/entity/MyBmHistory.java
@@ -14,11 +14,11 @@ public class MyBmHistory {
     @Column(name = "my_bm_history_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bm_id")
     private Bm bm;
 

--- a/src/main/java/com/pitchain/service/BmService.java
+++ b/src/main/java/com/pitchain/service/BmService.java
@@ -61,7 +61,7 @@ public class BmService {
         String descImgURL = s3Service.getFileURL(bm.getDescImgKey());
 
         myBmHistoryRepository.findByMemberAndBm(member, bm)
-                .orElse(myBmHistoryRepository.save(new MyBmHistory(member, bm)));
+                .orElseGet(() -> myBmHistoryRepository.save(new MyBmHistory(member, bm)));
 
         return BmDetailRes.createRes(bmWithLikeDto, likeCnt, ptImgResList, subCategories, spURL, logoImgURL, descImgURL);
     }


### PR DESCRIPTION
## ⭐ Summary

> #115 

<br>

## 📌 Tasks

1. MyBmHistory 연관관계 수정
2. Bm 상세 조회에서 MyBmHistory 저장 로직 반복 제거
