### PR TITLE
[feat] 사용자 선호도 정보 조회 및 ai로 데이터 전송

### DIFF
--- a/src/main/java/com/pitchain/controller/AIController.java
+++ b/src/main/java/com/pitchain/controller/AIController.java
@@ -1,0 +1,32 @@
+package com.pitchain.controller;
+
+import com.pitchain.dto.res.MemberPreferenceInfoRes;
+import com.pitchain.dto.res.PreferenceInfoRes;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@RestController
+public class AIController {
+
+    @Operation(summary = "AI 서버로 유저 선호도 정보 전송 / 개발용")
+    @GetMapping("/dev-model")
+    public String devAI() {
+        List<MemberPreferenceInfoRes> memberPreferenceInfoResList = List.of(
+                new MemberPreferenceInfoRes(1L, List.of(
+                        new PreferenceInfoRes(1L, 10, true, false),
+                        new PreferenceInfoRes(2L, 20, false, true)
+                )),
+                new MemberPreferenceInfoRes(2L, List.of(
+                        new PreferenceInfoRes(3L, 30, true, true),
+                        new PreferenceInfoRes(4L, 40, false, false)
+                ))
+        );
+
+        new RestTemplate().postForObject("http://localhost:8000/models", memberPreferenceInfoResList, Void.class);
+        return "ok";
+    }
+}

--- a/src/main/java/com/pitchain/dto/PreferenceInfoDto.java
+++ b/src/main/java/com/pitchain/dto/PreferenceInfoDto.java
@@ -1,0 +1,10 @@
+package com.pitchain.dto;
+
+public record PreferenceInfoDto(
+        Long memberId,
+        Long bmId,
+        int spViewTime,
+        Boolean isViewed,
+        Boolean isInvested
+) {
+}

--- a/src/main/java/com/pitchain/dto/res/MemberPreferenceInfoRes.java
+++ b/src/main/java/com/pitchain/dto/res/MemberPreferenceInfoRes.java
@@ -1,0 +1,9 @@
+package com.pitchain.dto.res;
+
+import java.util.List;
+
+public record MemberPreferenceInfoRes(
+        Long memberId,
+        List<PreferenceInfoRes> preferenceInfoResList
+) {
+}

--- a/src/main/java/com/pitchain/dto/res/PreferenceInfoRes.java
+++ b/src/main/java/com/pitchain/dto/res/PreferenceInfoRes.java
@@ -1,0 +1,19 @@
+package com.pitchain.dto.res;
+
+import com.pitchain.dto.PreferenceInfoDto;
+
+public record PreferenceInfoRes(
+        Long bmId,
+        int spViewTime,
+        Boolean isViewed,
+        Boolean isInvested
+) {
+    public static PreferenceInfoRes createRes(PreferenceInfoDto preferenceInfoDto) {
+        return new PreferenceInfoRes(
+                preferenceInfoDto.bmId(),
+                preferenceInfoDto.spViewTime(),
+                preferenceInfoDto.isViewed(),
+                preferenceInfoDto.isInvested()
+        );
+    }
+}

--- a/src/main/java/com/pitchain/entity/Investment.java
+++ b/src/main/java/com/pitchain/entity/Investment.java
@@ -29,7 +29,7 @@ public class Investment  extends BaseEntity {
     private long amount;
 
     @Builder
-    private Investment(Member member, Bm bm, long amount) {
+    public Investment(Member member, Bm bm, long amount) {
         this.member = member;
         this.bm = bm;
         this.amount = amount;

--- a/src/main/java/com/pitchain/repository/MemberRepository.java
+++ b/src/main/java/com/pitchain/repository/MemberRepository.java
@@ -1,7 +1,27 @@
 package com.pitchain.repository;
 
+import com.pitchain.dto.PreferenceInfoDto;
 import com.pitchain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("""
+                SELECT new com.pitchain.dto.PreferenceInfoDto(
+                    m.id,
+                    bm.id,
+                    COALESCE(sp.viewTime, 0),
+                    CASE WHEN mbh.id IS NOT NULL THEN true ELSE false END,
+                    CASE WHEN i.id IS NOT NULL THEN true ELSE false END
+                )
+                FROM Member m
+                CROSS JOIN Bm bm
+                LEFT JOIN MyBmHistory mbh ON bm.id = mbh.bm.id AND mbh.member.id = m.id
+                LEFT JOIN MySpHistory sp ON bm.id = sp.bm.id AND sp.member.id = m.id
+                LEFT JOIN Investment  i ON bm.id = i.bm.id AND i.member.id = m.id
+            """)
+    List<PreferenceInfoDto> getMemberPreferenceInfos();
 }

--- a/src/main/java/com/pitchain/service/AIService.java
+++ b/src/main/java/com/pitchain/service/AIService.java
@@ -1,0 +1,51 @@
+package com.pitchain.service;
+
+import com.pitchain.dto.PreferenceInfoDto;
+import com.pitchain.dto.res.MemberPreferenceInfoRes;
+import com.pitchain.dto.res.PreferenceInfoRes;
+import com.pitchain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class AIService {
+
+    @Value("${ai.model-url}")
+    private String modelUrl;
+
+    private final MemberRepository memberRepository;
+
+    // 매주 월요일 새벽 4시
+    @Scheduled(cron = "0 0 4 * * MON", zone = "Asia/Seoul")
+    public void sendMemberPreferenceInfos2AIServer() {
+        List<PreferenceInfoDto> preferenceInfoDtos = memberRepository.getMemberPreferenceInfos();
+
+        Map<Long, List<PreferenceInfoDto>> preferenceInfoGroupedByMemberId = preferenceInfoDtos.stream().collect(Collectors.groupingBy(PreferenceInfoDto::memberId));
+
+        List<MemberPreferenceInfoRes> memberPreferenceInfoResList = preferenceInfoGroupedByMemberId.entrySet().stream()
+                .map(entry -> {
+                    Long memberId = entry.getKey();
+                    List<PreferenceInfoRes> preferenceInfoResList = entry.getValue().stream()
+                            .map(PreferenceInfoRes::createRes)
+                            .toList();
+                    return new MemberPreferenceInfoRes(memberId, preferenceInfoResList);
+                })
+                .toList();
+
+        send2AIServer(memberPreferenceInfoResList);
+    }
+
+    private static void send2AIServer(List<MemberPreferenceInfoRes> memberPreferenceInfoResList) {
+        new RestTemplate().postForObject("modelUrl", memberPreferenceInfoResList, Void.class);
+    }
+}

--- a/src/test/java/com/pitchain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/pitchain/repository/MemberRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.pitchain.repository;
+
+import com.pitchain.common.constant.Country;
+import com.pitchain.common.constant.MainCategory;
+import com.pitchain.dto.res.MemberPreferenceInfoRes;
+import com.pitchain.dto.PreferenceInfoDto;
+import com.pitchain.dto.res.PreferenceInfoRes;
+import com.pitchain.entity.*;
+import org.apache.logging.log4j.util.Strings;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BmRepository bmRepository;
+    @Autowired
+    private SpRepository spRepository;
+    @Autowired
+    private InvestmentRepository investmentRepository;
+    @Autowired
+    private MyBmHistoryRepository myBmHistoryRepository;
+    @Autowired
+    private MySpHistoryRepository mySpHistoryRepository;
+
+    private Member saveMember() {
+        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+    }
+
+    private Bm saveBm(Member member) {
+        return bmRepository.save(new Bm(member, "bm_name", MainCategory.FOOD, "bm_company", "bm_logo_img_key",
+                "bm_intro", "bm_description", "bm_desc_img_key", "bm_address", 100000L,
+                1000L, 1000, LocalDate.now(), "bm_long_pitch_url"));
+    }
+
+    private Bm saveBmWithMainCategory(Member member, MainCategory mainCategory) {
+        return bmRepository.save(new Bm(member, "bm_name", mainCategory, "bm_company", "bm_logo_img_key",
+                "bm_intro", "bm_description", "bm_desc_img_key", "bm_address", 100000L,
+                1000L, 1000, LocalDate.now(), "bm_long_pitch_url"));
+    }
+
+    private Sp saveSp(Bm bm) {
+        return spRepository.save(new Sp(bm, SP_KEY, THUMBNAIL_IMG.getOriginalFilename(), SP_NAME));
+    }
+
+    private static final String SP_NAME = "sp_name";
+    private static final String SP_KEY = "sp_vid.m3u8";
+    private static final MockMultipartFile THUMBNAIL_IMG = new MockMultipartFile(
+            "thumbnail_img", "thumbnail_img.png", "image/png", "test data 2".getBytes());
+
+    @Test
+    void 유저_선호도_정보_조회() {
+        // given
+        Member member_1 = saveMember();
+        Member member_2 = saveMember();
+        Member member_3 = saveMember();
+        Member member_4 = saveMember();
+
+        Bm bm_1 = saveBmWithMainCategory(member_1, MainCategory.FOOD);
+
+        Bm bm_2 = saveBmWithMainCategory(member_2, MainCategory.FOOD);
+        investmentRepository.save(new Investment(member_2, bm_2, 2000L));
+
+        Bm bm_3 = saveBmWithMainCategory(member_3, MainCategory.FOOD);
+        investmentRepository.save(new Investment(member_3, bm_3, 3000L));
+        mySpHistoryRepository.save(new MySpHistory(member_3, bm_3, 98765));
+
+        Bm bm_4 = saveBmWithMainCategory(member_4, MainCategory.FOOD);
+        investmentRepository.save(new Investment(member_4, bm_4, 4000L));
+        mySpHistoryRepository.save(new MySpHistory(member_4, bm_4, 123456));
+        myBmHistoryRepository.save(new MyBmHistory(member_4, bm_4));
+
+        // when
+        List<PreferenceInfoDto> preferenceInfoDtos = memberRepository.getMemberPreferenceInfos();
+
+        // then
+        Map<Long, List<PreferenceInfoDto>> preferenceInfoGroupedByMemberId = preferenceInfoDtos.stream().collect(Collectors.groupingBy(PreferenceInfoDto::memberId));
+
+        List<MemberPreferenceInfoRes> memberPreferenceInfoResList = preferenceInfoGroupedByMemberId.entrySet().stream()
+                .map(entry -> {
+                    Long memberId = entry.getKey();
+                    List<PreferenceInfoRes> preferenceInfoResList = entry.getValue().stream().map(PreferenceInfoRes::createRes).toList();
+                    return new MemberPreferenceInfoRes(memberId, preferenceInfoResList);
+                })
+                .toList();
+
+        System.out.println("memberPreferenceInfoResList = " + memberPreferenceInfoResList);
+
+        assertThat(preferenceInfoDtos.size()).isEqualTo(16);
+    }
+}


### PR DESCRIPTION
## ⭐ Summary

> #119

<br>

## 📌 Tasks

1. 사용자 선호도 정보 조회 및 ai로 데이터 전송

<br>

## ETC

모든 사용자에 대해 각 사용자의 모든 bm에 대한 선호도(bmId, sp 시청시간, bm 디테일 조회 여부, bm 투자여부)를 조회해야 한다.
따라서 cross join으로 데이터가 너무 많아져서 테스트 코드는 데이터 갯수 및 출력문을 통해 확인 했습니다

