### PR TITLE
[feat] Oauth 로그인 구현

### DIFF
--- a/src/main/java/com/pitchain/common/constant/OauthProvider.java
+++ b/src/main/java/com/pitchain/common/constant/OauthProvider.java
@@ -1,0 +1,16 @@
+package com.pitchain.common.constant;
+
+import com.pitchain.oauth2.param.GoogleParams;
+import com.pitchain.oauth2.param.KakaoParams;
+import com.pitchain.oauth2.param.OauthParams;
+
+public enum OauthProvider {
+    KAKAO, GOOGLE;
+
+    public OauthParams getOauthParams(String code) {
+        return switch (this) {
+            case KAKAO -> new KakaoParams(code);
+            case GOOGLE -> new GoogleParams(code);
+        };
+    }
+}

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -1,0 +1,35 @@
+package com.pitchain.controller;
+
+import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.dto.req.OauthLoginReq;
+import com.pitchain.dto.res.OauthLoginRes;
+import com.pitchain.service.OauthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "소셜 로그인")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/oauth2")
+public class OauthController {
+    private final OauthService oauthService;
+
+    @Operation(summary = "소셜 로그인", description = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=47fe7aff98cf882892387fe4b65d3279&redirect_uri={redirectURL}을 통해 code값 받아오기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "COMMON400", description = "처리할 수 없는 소셜 로그인")}
+    )
+    @PostMapping("/login")
+    public CustomApiResponse<OauthLoginRes> socialLogin(@Valid @RequestBody OauthLoginReq req) {
+        OauthLoginRes memberByOauthLogin = oauthService.getMemberByOauthLogin(req);
+        return CustomApiResponse.onSuccess(memberByOauthLogin);
+    }
+}

--- a/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
+++ b/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
@@ -1,0 +1,22 @@
+package com.pitchain.dto.req;
+
+import com.pitchain.common.constant.OauthProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OauthLoginReq {
+    @NotNull
+    @Schema(description = "소셜 로그인 제공자", examples = {"KAKAO", "GOOGLE", "APPLE"})
+    private OauthProvider oauthProvider;
+
+    @NotBlank
+    @Schema(description = "OAuth Provider Server로 부터 받은 인증 코드")
+    private String code;
+}

--- a/src/main/java/com/pitchain/dto/res/OauthLoginRes.java
+++ b/src/main/java/com/pitchain/dto/res/OauthLoginRes.java
@@ -1,0 +1,15 @@
+package com.pitchain.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthLoginRes {
+    private String accessToken;
+    private String refreshToken;
+
+    public static OauthLoginRes createRes(String accessToken, String refreshToken) {
+        return new OauthLoginRes(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = {@UniqueConstraint(name = "EMAIL_UNIQUE", columnNames = {"email"})})
+@Table
 public class Member extends BaseEntity {
 
     @Id
@@ -24,9 +24,6 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
-
-    @Column(nullable = false)
-    private String email;
 
     @Enumerated(EnumType.STRING)
     private Country country;
@@ -45,9 +42,8 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CategoryPref> categoryPrefs = new ArrayList<>();
 
-    public Member(String name, String email, Country country, String profileImgKey) {
+    public Member(String name, Country country, String profileImgKey) {
         this.name = name;
-        this.email = email;
         this.country = country;
         this.profileImgKey = profileImgKey;
     }

--- a/src/main/java/com/pitchain/entity/Member.java
+++ b/src/main/java/com/pitchain/entity/Member.java
@@ -1,8 +1,10 @@
 package com.pitchain.entity;
 
 import com.pitchain.common.constant.Country;
+import com.pitchain.common.constant.OauthProvider;
 import com.pitchain.common.constant.SubCategory;
 import com.pitchain.common.entity.BaseEntity;
+import com.pitchain.oauth2.member.OauthMemberInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,6 +32,10 @@ public class Member extends BaseEntity {
 
     private String profileImgKey;
 
+    private String socialId;
+
+    private OauthProvider oauthProvider;
+
     @OneToMany(mappedBy = "member")
     private List<Investment> investments = new ArrayList<>();
 
@@ -46,6 +52,11 @@ public class Member extends BaseEntity {
         this.name = name;
         this.country = country;
         this.profileImgKey = profileImgKey;
+    }
+
+    public Member(OauthMemberInfo request) {
+        this.socialId = request.getSocialId();
+        this.oauthProvider = request.getOauthProvider();
     }
 
     public void addCategoryPref(List<SubCategory> subCategories) {

--- a/src/main/java/com/pitchain/oauth2/client/GoogleClient.java
+++ b/src/main/java/com/pitchain/oauth2/client/GoogleClient.java
@@ -1,0 +1,91 @@
+package com.pitchain.oauth2.client;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.oauth2.member.GoogleMemberInfo;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+import com.pitchain.oauth2.token.GoogleToken;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class GoogleClient implements OauthClient {
+    @Value("${oauth.google.token_url}")
+    private String token_url;
+    @Value("${oauth.google.user_url}")
+    private String user_url;
+    @Value("${oauth.google.grant_type}")
+    private String grant_type;
+    @Value("${oauth.google.client_id}")
+    private String client_id;
+    @Value("${oauth.google.client_secret}")
+    private String client_secret;
+    @Value("${oauth.google.redirect_uri}")
+    private String redirect_uri;
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.GOOGLE;
+    }
+
+    @Override
+    public String getOauthLoginToken(OauthParams oauthParams) {
+        String url = token_url;
+        log.debug("Authorization code: " + oauthParams.getAuthorizationCode());
+
+        RestTemplate rt = new RestTemplate();
+        // 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 바디 생성
+        MultiValueMap<String, String> body = oauthParams.makeBody();
+        body.add("grant_type", grant_type);
+        body.add("client_id", client_id);
+        body.add("client_secret", client_secret);
+        body.add("redirect_uri", redirect_uri);
+
+        // 헤더 + 바디 결합
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(body, headers);
+        log.debug("Current httpEntity state: " + tokenRequest);
+
+        // 토큰 수신
+        GoogleToken googleToken = rt.postForObject(url, tokenRequest, GoogleToken.class);
+        log.debug("accessToken: " + googleToken);
+
+        if (googleToken == null) {
+            log.error("google token을 정상적으로 가져오지 못했습니다.");
+            throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        }
+
+        return googleToken.getAccess_token();
+    }
+
+    @Override
+    public OauthMemberInfo getMemberInfo(String accessToken) {
+        String url = user_url;
+        log.debug("Received token: " + accessToken);
+
+        // 요청 객체 생성
+        RestTemplate rt = new RestTemplate();
+
+        // 헤더 생성
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.add("Authorization", "Bearer " + accessToken);
+
+        // Google 사용자 정보 요청 시 바디는 필요 없음
+        HttpEntity<String> memberInfoRequest = new HttpEntity<>(httpHeaders);
+
+        return rt.postForObject(url, memberInfoRequest, GoogleMemberInfo.class);
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/client/KakaoClient.java
+++ b/src/main/java/com/pitchain/oauth2/client/KakaoClient.java
@@ -1,0 +1,96 @@
+package com.pitchain.oauth2.client;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.oauth2.member.KakaoMemberInfo;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+import com.pitchain.oauth2.token.KakaoToken;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class KakaoClient implements OauthClient{
+    @Value("${oauth.kakao.token_url}")
+    private String token_url;
+    @Value("${oauth.kakao.user_url}")
+    private String user_url;
+    @Value("${oauth.kakao.grant_type}")
+    private String grant_type;
+    @Value("${oauth.kakao.client_id}")
+    private String client_id;
+    @Value("${oauth.kakao.client_secret}")
+    private String client_secret;
+    @Value("${oauth.kakao.redirect_uri}")
+    private String redirect_uri;
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.KAKAO;
+    }
+
+    @Override
+    public String getOauthLoginToken(OauthParams oauthParams) {
+        String url = token_url;
+        log.debug("Authorization code: " + oauthParams.getAuthorizationCode());
+
+        //rest object 생성
+        RestTemplate rt = new RestTemplate();
+        //헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        //바디 생성
+        MultiValueMap<String, String> body = oauthParams.makeBody();
+        body.add("grant_type", grant_type);
+        body.add("client_id", client_id);
+        body.add("client_secret", client_secret);
+        body.add("redirect_uri", redirect_uri);
+
+        //헤더 + 바디
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(body, headers);
+        log.debug("Current httpEntity state: " + tokenRequest);
+
+        //소셜토큰 수신
+        KakaoToken kakaoToken = rt.postForObject(url, tokenRequest, KakaoToken.class);
+        log.debug("accessToken: " + kakaoToken);
+
+        if (kakaoToken == null) {
+            log.error("kakao token을 정상적으로 가져오지 못했습니다.");
+            throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        }
+
+        return kakaoToken.getAccess_token();
+    }
+
+    @Override
+    public OauthMemberInfo getMemberInfo(String accessToken) {
+        String url = user_url;
+
+        //rest object 생성
+        RestTemplate rt = new RestTemplate();
+
+        //헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        //바디 생성
+        LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+
+        //헤더 + 바디
+        HttpEntity<LinkedMultiValueMap<String, String>> memberInfoRequest = new HttpEntity<>(body, headers);
+
+        return rt.postForObject(url, memberInfoRequest, KakaoMemberInfo.class);
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/client/OauthClient.java
+++ b/src/main/java/com/pitchain/oauth2/client/OauthClient.java
@@ -1,0 +1,14 @@
+package com.pitchain.oauth2.client;
+
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+
+public interface OauthClient {
+    OauthProvider oauthProvider();
+
+    String getOauthLoginToken(OauthParams oauthParams);
+
+    OauthMemberInfo getMemberInfo(String accessToken);
+
+}

--- a/src/main/java/com/pitchain/oauth2/member/GoogleMemberInfo.java
+++ b/src/main/java/com/pitchain/oauth2/member/GoogleMemberInfo.java
@@ -1,0 +1,40 @@
+package com.pitchain.oauth2.member;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pitchain.common.constant.OauthProvider;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleMemberInfo implements OauthMemberInfo {
+    @JsonProperty("sub")
+    private String id;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("name")
+    private String name;
+    @Override
+    public String getSocialId() {
+        return id;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getNickname() {
+        return name;
+    }
+
+    @Override
+    public OauthProvider getOauthProvider() {
+        return OauthProvider.GOOGLE;
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/member/KakaoMemberInfo.java
+++ b/src/main/java/com/pitchain/oauth2/member/KakaoMemberInfo.java
@@ -1,0 +1,50 @@
+package com.pitchain.oauth2.member;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pitchain.common.constant.OauthProvider;
+import lombok.Getter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoMemberInfo implements OauthMemberInfo {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+        private Profile profile;
+        private String email;
+
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile{
+            private String nickname;
+        }
+    }
+
+    @Override
+    public String getSocialId() {
+        return id;
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public OauthProvider getOauthProvider() {
+        return OauthProvider.KAKAO;
+    }
+
+
+}

--- a/src/main/java/com/pitchain/oauth2/member/OauthMemberInfo.java
+++ b/src/main/java/com/pitchain/oauth2/member/OauthMemberInfo.java
@@ -1,0 +1,13 @@
+package com.pitchain.oauth2.member;
+
+import com.pitchain.common.constant.OauthProvider;
+
+public interface OauthMemberInfo {
+    String getSocialId();
+
+    String getEmail();
+
+    String getNickname();
+
+    OauthProvider getOauthProvider();
+}

--- a/src/main/java/com/pitchain/oauth2/param/GoogleParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/GoogleParams.java
@@ -1,0 +1,34 @@
+package com.pitchain.oauth2.param;
+
+import com.pitchain.common.constant.OauthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@AllArgsConstructor
+public class GoogleParams implements OauthParams {
+    private String authorizationCode;
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.GOOGLE;
+    }
+
+    @Override
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        String decode = URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8);
+        body.add("code", decode);
+        return body;
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/param/KakaoParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/KakaoParams.java
@@ -1,0 +1,30 @@
+package com.pitchain.oauth2.param;
+
+import com.pitchain.common.constant.OauthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@AllArgsConstructor
+public class KakaoParams implements OauthParams {
+    private String authorizationCode;
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.KAKAO;
+    }
+
+    @Override
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/param/OauthParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/OauthParams.java
@@ -1,0 +1,13 @@
+package com.pitchain.oauth2.param;
+
+
+import com.pitchain.common.constant.OauthProvider;
+import org.springframework.util.MultiValueMap;
+
+public interface OauthParams {
+    OauthProvider oauthProvider();
+
+    String getAuthorizationCode();
+
+    MultiValueMap<String, String> makeBody();
+}

--- a/src/main/java/com/pitchain/oauth2/token/GoogleToken.java
+++ b/src/main/java/com/pitchain/oauth2/token/GoogleToken.java
@@ -1,0 +1,13 @@
+package com.pitchain.oauth2.token;
+
+import lombok.Data;
+
+@Data
+public class GoogleToken {
+    private String access_token;
+    private String expires_in;
+    private String refresh_token;
+    private String scope;
+    private String token_type;
+    private String id_token;
+}

--- a/src/main/java/com/pitchain/oauth2/token/KakaoToken.java
+++ b/src/main/java/com/pitchain/oauth2/token/KakaoToken.java
@@ -1,0 +1,14 @@
+package com.pitchain.oauth2.token;
+
+import lombok.Data;
+
+@Data
+public class KakaoToken {
+    private String token_type;
+    private String access_token;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private int refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/pitchain/repository/MemberRepository.java
+++ b/src/main/java/com/pitchain/repository/MemberRepository.java
@@ -1,11 +1,13 @@
 package com.pitchain.repository;
 
+import com.pitchain.common.constant.OauthProvider;
 import com.pitchain.dto.PreferenceInfoDto;
 import com.pitchain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -24,4 +26,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                 LEFT JOIN Investment  i ON bm.id = i.bm.id AND i.member.id = m.id
             """)
     List<PreferenceInfoDto> getMemberPreferenceInfos();
+
+    Optional<Member> findByOauthProviderAndSocialId(OauthProvider oauthProvider, String socialId);
 }

--- a/src/main/java/com/pitchain/service/AIService.java
+++ b/src/main/java/com/pitchain/service/AIService.java
@@ -15,7 +15,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Transactional
@@ -54,7 +53,7 @@ public class AIService {
 
     public Long createMember() {
         return memberRepository.save(
-                new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg.jpg")
+                new Member("name", Country.USA, "profileImg.jpg")
         ).getId();
     }
 }

--- a/src/main/java/com/pitchain/service/OauthService.java
+++ b/src/main/java/com/pitchain/service/OauthService.java
@@ -1,0 +1,47 @@
+package com.pitchain.service;
+
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.dto.req.OauthLoginReq;
+import com.pitchain.dto.res.OauthLoginRes;
+import com.pitchain.entity.Member;
+import com.pitchain.jwt.TokenUtil;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+import com.pitchain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class OauthService {
+    private final RequestOauthInfoService requestOauthInfoService;
+    private final TokenUtil tokenUtil;
+    private final MemberRepository memberRepository;
+
+    public OauthLoginRes getMemberByOauthLogin(OauthLoginReq req) {
+        OauthParams oauthParam = createOauthParams(req);
+
+        OauthMemberInfo oauthMemberInfo = requestOauthInfoService.request(oauthParam);
+        Optional<Member> byOauthProviderAndSocialId = memberRepository.findByOauthProviderAndSocialId(oauthMemberInfo.getOauthProvider(), oauthMemberInfo.getSocialId());
+
+        Member member = byOauthProviderAndSocialId.orElseGet(() -> memberRepository.save(new Member(oauthMemberInfo)));
+
+        String accessToken = tokenUtil.issueAccessToken(member.getId());
+        String refreshToken = tokenUtil.issueRefreshToken(member.getId());
+
+        return OauthLoginRes.createRes(accessToken, refreshToken);
+    }
+
+    private static OauthParams createOauthParams(OauthLoginReq req) {
+        OauthProvider oauthProvider = req.getOauthProvider();
+        OauthParams oauthParam = oauthProvider.getOauthParams(req.getCode());
+        return oauthParam;
+    }
+
+}

--- a/src/main/java/com/pitchain/service/RequestOauthInfoService.java
+++ b/src/main/java/com/pitchain/service/RequestOauthInfoService.java
@@ -1,0 +1,28 @@
+package com.pitchain.service;
+
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.oauth2.client.OauthClient;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOauthInfoService {
+    private final Map<OauthProvider, OauthClient> clients;
+
+    public RequestOauthInfoService(List<OauthClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OauthClient::oauthProvider, Function.identity()));
+    }
+
+    public OauthMemberInfo request(OauthParams oauthParams) {
+        OauthClient client = clients.get(oauthParams.oauthProvider());
+        String accessToken = client.getOauthLoginToken(oauthParams);
+        return client.getMemberInfo(accessToken);
+    }
+}

--- a/src/test/java/com/pitchain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/pitchain/repository/MemberRepositoryTest.java
@@ -2,12 +2,11 @@ package com.pitchain.repository;
 
 import com.pitchain.common.constant.Country;
 import com.pitchain.common.constant.MainCategory;
-import com.pitchain.dto.res.MemberPreferenceInfoRes;
 import com.pitchain.dto.PreferenceInfoDto;
+import com.pitchain.dto.res.MemberPreferenceInfoRes;
 import com.pitchain.dto.res.PreferenceInfoRes;
 import com.pitchain.entity.*;
 import org.apache.logging.log4j.util.Strings;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -16,10 +15,9 @@ import org.springframework.mock.web.MockMultipartFile;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class MemberRepositoryTest {
@@ -38,7 +36,7 @@ class MemberRepositoryTest {
     private MySpHistoryRepository mySpHistoryRepository;
 
     private Member saveMember() {
-        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+        return memberRepository.save(new Member("member_name", Country.ROK, Strings.EMPTY));
     }
 
     private Bm saveBm(Member member) {

--- a/src/test/java/com/pitchain/service/BmPrefServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmPrefServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,7 +61,7 @@ class BmPrefServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg.jpg"));
+        return memberRepository.save(new Member("name", Country.USA, "profileImg.jpg"));
     }
 
 }

--- a/src/test/java/com/pitchain/service/BmServiceTest.java
+++ b/src/test/java/com/pitchain/service/BmServiceTest.java
@@ -10,7 +10,10 @@ import com.pitchain.dto.req.CreateBmReq;
 import com.pitchain.dto.req.UpdateBmReq;
 import com.pitchain.dto.res.BmDetailRes;
 import com.pitchain.dto.res.PtImgRes;
-import com.pitchain.entity.*;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.Member;
+import com.pitchain.entity.MyBm;
+import com.pitchain.entity.PtImg;
 import com.pitchain.repository.BmRepository;
 import com.pitchain.repository.MemberRepository;
 import com.pitchain.repository.MyBmHistoryRepository;
@@ -22,12 +25,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -71,7 +73,7 @@ class BmServiceTest {
             "description", "description.png", "image/png", "test data 2".getBytes());
 
     private Member saveMember() {
-        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+        return memberRepository.save(new Member("member_name", Country.ROK, Strings.EMPTY));
     }
 
     private Bm saveBm(Member member) {

--- a/src/test/java/com/pitchain/service/CommentServiceTest.java
+++ b/src/test/java/com/pitchain/service/CommentServiceTest.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.transaction.annotation.Propagation.NEVER;
@@ -303,11 +302,11 @@ class CommentServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg.jpg"));
+        return memberRepository.save(new Member("name", Country.USA, "profileImg.jpg"));
     }
 
     private Bm saveBm(Member member) {
-        return bmRepository.save(new Bm(member, "bmName", MainCategory.FOOD,"bmCompany", "logoImg",
+        return bmRepository.save(new Bm(member, "bmName", MainCategory.FOOD, "bmCompany", "logoImg",
                 "bmIntro", "bmDescription", "bmDescriptionImg", "companyAddress", 100000L,
                 1000L, 1000, LocalDate.now(), "longPitchUrl"));
     }

--- a/src/test/java/com/pitchain/service/InvestmentServiceTest.java
+++ b/src/test/java/com/pitchain/service/InvestmentServiceTest.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,7 +66,7 @@ class InvestmentServiceTest {
 
         //when
         GeneralHandler error1 = Assertions.assertThrows(GeneralHandler.class, () -> investmentService.addInvestment(invalidId, member.getId(), amount));
-        GeneralHandler error2 = Assertions.assertThrows(GeneralHandler.class, () -> investmentService.addInvestment(bm.getId(),invalidId, amount));
+        GeneralHandler error2 = Assertions.assertThrows(GeneralHandler.class, () -> investmentService.addInvestment(bm.getId(), invalidId, amount));
 
         //then
         assertThat(error1.getErrorStatus()).isEqualTo(ErrorStatus.BM_NOT_FOUND);
@@ -93,7 +92,7 @@ class InvestmentServiceTest {
         InvestmentStatusRes investmentStatus = investmentService.getInvestmentStatus(bmId);
 
         //then
-        Bm bm  = bmRepository.findById(bmId).orElseThrow();
+        Bm bm = bmRepository.findById(bmId).orElseThrow();
         assertThat(investmentStatus.deadline()).isEqualTo(bm.getDeadline());
         assertThat(investmentStatus.pricePerShare()).isEqualTo(bm.getPricePerShare());
         assertThat(investmentStatus.maxIssuedShare()).isEqualTo(bm.getMaxIssuedShare());
@@ -110,7 +109,7 @@ class InvestmentServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg"));
+        return memberRepository.save(new Member("name", Country.USA, "profileImg"));
     }
 
     private Bm saveBm(Member member) {

--- a/src/test/java/com/pitchain/service/MyBmServiceTest.java
+++ b/src/test/java/com/pitchain/service/MyBmServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,11 +64,11 @@ class MyBmServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg"));
+        return memberRepository.save(new Member("name", Country.USA, "profileImg"));
     }
 
     private Bm saveBm(Member member) {
-        Bm bm = new Bm(member, "bmName", MainCategory.FOOD,"bmCompany", "logoImg",
+        Bm bm = new Bm(member, "bmName", MainCategory.FOOD, "bmCompany", "logoImg",
                 "bmIntro", "bmDescription", "bmDescriptionImg", "companyAddress", 100000L,
                 1000L, 1000, LocalDate.now(), "longPitchUrl");
         return bmRepository.save(bm);

--- a/src/test/java/com/pitchain/service/MySpHistoryServiceTest.java
+++ b/src/test/java/com/pitchain/service/MySpHistoryServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 @Transactional
 @SpringBootTest
@@ -75,11 +74,11 @@ class MySpHistoryServiceTest {
     }
 
     private Member saveMember() {
-        return memberRepository.save(new Member("name", UUID.randomUUID().toString(), Country.USA, "profileImg.jpg"));
+        return memberRepository.save(new Member("name", Country.USA, "profileImg.jpg"));
     }
 
     private Bm saveBm(Member member) {
-        return bmRepository.save(new Bm(member, "bmName", MainCategory.FOOD,"bmCompany", "logoImg",
+        return bmRepository.save(new Bm(member, "bmName", MainCategory.FOOD, "bmCompany", "logoImg",
                 "bmIntro", "bmDescription", "bmDescriptionImg", "companyAddress", 100000L,
                 1000L, 1000, LocalDate.now(), "longPitchUrl"));
     }

--- a/src/test/java/com/pitchain/service/SpServiceTest.java
+++ b/src/test/java/com/pitchain/service/SpServiceTest.java
@@ -8,7 +8,6 @@ import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.entity.*;
 import com.pitchain.repository.*;
-import jakarta.persistence.EntityManager;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -48,7 +46,7 @@ class SpServiceTest {
     private CategoryPrefRepository categoryPrefRepository;
 
     private Member saveMember() {
-        return memberRepository.save(new Member("member_name", UUID.randomUUID().toString(), Country.ROK, Strings.EMPTY));
+        return memberRepository.save(new Member("member_name", Country.ROK, Strings.EMPTY));
     }
 
     private Bm saveBm(Member member) {


### PR DESCRIPTION
## ⭐ Summary

> #134

<br>

## 📌 Tasks

1. 카카오 로그인
2. 구글 로그인

## ETC
- 기존에 사용하던 oauth 로그인 코드 가져와서 약간 수정해봤습니다
- 구글은 클라이언트 등록 안 해뒀고, 네이버는 아직 보류해뒀습니다.
- 코드 리뷰 진행 후 수정사항 생길 것 같아서 카카오까지만 테스트 완료했습니다.
- 선 코드 리뷰 후 구글, 네이버 마무리 하겠습니다!
- yml 수정

## Oauth Login 테스트
https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri=http://localhost:8080

1. 위 링크 접속 후 카카오 로그인
2. Redirect URL의  쿼리파라미터에서 code 값 조회
3. /oauth2/login에 바디 채워서 전송
    ```
    {
      "oauthProvider": "KAKAO",
      "code": "{code}"
    }
    ```

