### PR TITLE
[refactor] 원화 기준 환율 -> 달러 기준 환율로 변경

### DIFF
--- a/src/main/java/com/pitchain/service/ExchangeRateService.java
+++ b/src/main/java/com/pitchain/service/ExchangeRateService.java
@@ -41,6 +41,7 @@ public class ExchangeRateService {
      * 가장 최근의 통화별 일환율 조회
      * 일환율 업데이트 전이면 어제 환율 조회
      * 일환율 업데이트 후면 오늘 환율 조회
+     *
      * @return
      */
     public Map<String, String> getLatestExchangeRateMap() {
@@ -54,6 +55,7 @@ public class ExchangeRateService {
      * 한국수출입은행 현재환율 API 호출을 통한 통화별 일환율 조회 및 DB에 저장
      * 비영업일이면 어제 일환율을 저장
      * 매일 11시 30분 업데이트
+     *
      * @return Map<String, String>
      */
     @Scheduled(cron = "${koreaexim.updateTime.cron}")
@@ -61,22 +63,35 @@ public class ExchangeRateService {
         String uri = generateRequestURI();
         ExchangeRateRes[] exchangeRateList = restTemplate.getForObject(uri, ExchangeRateRes[].class);
 
-        String todayDate = getTodayDate();
-        Map<String, String> exchangeRateMap = getExchangeRateMap(exchangeRateList, todayDate);
+        Map<String, String> usdBasedExchangeRateMap = getExchangeRateMap(exchangeRateList);
 
-        redisExchangeRateUtil.setExchangeRateMap(todayDate, exchangeRateMap);
+        redisExchangeRateUtil.setExchangeRateMap(getTodayDate(), usdBasedExchangeRateMap);
     }
 
-    private Map<String, String> getExchangeRateMap(ExchangeRateRes[] exchangeRateList, String todayDate) {
+    private Map<String, String> getExchangeRateMap(ExchangeRateRes[] exchangeRateList) {
         if (isNonBusinessDay(exchangeRateList)) {
             return redisExchangeRateUtil.getExchangeRateMap(getYesterdayDate());
         }
 
-        return convertListToMap(exchangeRateList, todayDate);
-
+        Map<String, String> krwBasedExchangeRateMap = convertListToMap(exchangeRateList);
+        return convertToUsdBasedExchageRateMap(krwBasedExchangeRateMap);
     }
 
-    private Map<String, String> convertListToMap(ExchangeRateRes[] exchangeRateList, String date) {
+    private Map<String, String> convertToUsdBasedExchageRateMap(Map<String, String> krwBasedExchangeRateMap) {
+        Map<String, String> usdBasedExchangeRateMap = new HashMap<>();
+        String krw2Usd = krwBasedExchangeRateMap.get("USD");
+
+        for (String currency : krwBasedExchangeRateMap.keySet()) {
+            String exchangeRate = krwBasedExchangeRateMap.get(currency);
+            String usdBasedExchangeRate = String.format("%.2f", Double.parseDouble(krw2Usd) / Double.parseDouble(exchangeRate));
+
+            usdBasedExchangeRateMap.put(currency, usdBasedExchangeRate);
+        }
+
+        return usdBasedExchangeRateMap;
+    }
+
+    private Map<String, String> convertListToMap(ExchangeRateRes[] exchangeRateList) {
         Map<String, String> exchangeRateMap = new HashMap<>();
         for (ExchangeRateRes exchangeRate : exchangeRateList) {
             String curUnit = exchangeRate.getCur_unit();  //통화코드
@@ -84,7 +99,6 @@ public class ExchangeRateService {
 
             exchangeRateMap.put(curUnit, dealBasR);
         }
-        exchangeRateMap.put("updateDateTime", String.format("%s %02d:%02d", date, updateHour, updateMin));  //일환율 업데이트 일시
 
         return exchangeRateMap;
     }


### PR DESCRIPTION
## ⭐ Summary

> #137

<br>

## 📌 Tasks

1. 원화 기준 환율 -> 달러 기준 환율로 변경

<br>

## 🖼️ Screenshot

![image](https://github.com/user-attachments/assets/54b23d20-2806-4068-9138-50d047e81a74)

<br>

## ETC
추후 기능 개발 시 바로 활용할 수 있게 환율 정보만 미리 개발해뒀습니다

기존에 exChageRateMap에 통화 -> 환율 정보뿐만 아니라 updatetime도 추가해두셨던데 이유가 있나요??
활용되는 부분이 없어 보이고, 환율 계산 과정에서 Double로 타입캐스팅 시 에러 발생해서 삭제해두긴 했습니다
