### PR TITLE
[feat] 네이버 로그인 구현

### DIFF
--- a/src/main/java/com/pitchain/common/constant/OauthProvider.java
+++ b/src/main/java/com/pitchain/common/constant/OauthProvider.java
@@ -2,15 +2,17 @@ package com.pitchain.common.constant;
 
 import com.pitchain.oauth2.param.GoogleParams;
 import com.pitchain.oauth2.param.KakaoParams;
+import com.pitchain.oauth2.param.NaverParams;
 import com.pitchain.oauth2.param.OauthParams;
 
 public enum OauthProvider {
-    KAKAO, GOOGLE;
+    KAKAO, GOOGLE, NAVER;
 
-    public OauthParams getOauthParams(String code) {
+    public OauthParams getOauthParams(String code, String state) {
         return switch (this) {
             case KAKAO -> new KakaoParams(code);
             case GOOGLE -> new GoogleParams(code);
+            case NAVER -> new NaverParams(code, state);
         };
     }
 }

--- a/src/main/java/com/pitchain/common/constant/OauthProvider.java
+++ b/src/main/java/com/pitchain/common/constant/OauthProvider.java
@@ -1,5 +1,6 @@
 package com.pitchain.common.constant;
 
+import com.pitchain.dto.req.OauthLoginReq;
 import com.pitchain.oauth2.param.GoogleParams;
 import com.pitchain.oauth2.param.KakaoParams;
 import com.pitchain.oauth2.param.NaverParams;
@@ -8,7 +9,10 @@ import com.pitchain.oauth2.param.OauthParams;
 public enum OauthProvider {
     KAKAO, GOOGLE, NAVER;
 
-    public OauthParams getOauthParams(String code, String state) {
+    public OauthParams getOauthParams(OauthLoginReq req) {
+        String code = req.getCode();
+        String state = req.getState();
+
         return switch (this) {
             case KAKAO -> new KakaoParams(code);
             case GOOGLE -> new GoogleParams(code);

--- a/src/main/java/com/pitchain/common/constant/OauthProvider.java
+++ b/src/main/java/com/pitchain/common/constant/OauthProvider.java
@@ -9,17 +9,11 @@ import com.pitchain.oauth2.param.OauthParams;
 public enum OauthProvider {
     KAKAO, GOOGLE, NAVER;
 
-    public OauthParams getOauthParams(OauthLoginReq req) {
-        String code = req.getCode();
-        String state = req.getState();
-
+    public OauthParams getOauthParams(String code) {
         return switch (this) {
             case KAKAO -> new KakaoParams(code);
             case GOOGLE -> new GoogleParams(code);
-            case NAVER -> {
-                assert state != null : "state should not be null";
-                yield new NaverParams(code, state);
-            }
+            case NAVER -> new NaverParams(code);
         };
     }
 }

--- a/src/main/java/com/pitchain/common/constant/OauthProvider.java
+++ b/src/main/java/com/pitchain/common/constant/OauthProvider.java
@@ -16,7 +16,10 @@ public enum OauthProvider {
         return switch (this) {
             case KAKAO -> new KakaoParams(code);
             case GOOGLE -> new GoogleParams(code);
-            case NAVER -> new NaverParams(code, state);
+            case NAVER -> {
+                assert state != null : "state should not be null";
+                yield new NaverParams(code, state);
+            }
         };
     }
 }

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -20,7 +20,7 @@ public class OauthController {
     private final OauthService oauthService;
 
     @Operation(summary = "소셜 로그인", description = "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL}을 통해 code값 받아오기, " +
-                                                    "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&state={state}&redirect_uri={redirectURL}을 통해 code값 받아오기")
+                                                    "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&redirect_uri={redirectURL}을 통해 code값 받아오기")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "로그인 성공"),
             @ApiResponse(responseCode = "COMMON400", description = "처리할 수 없는 소셜 로그인")}

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.*;
 public class OauthController {
     private final OauthService oauthService;
 
-    @GetMapping("/")
-
     @Operation(summary = "소셜 로그인", description = "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL}을 통해 code값 받아오기, " +
                                                     "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&state={state}&redirect_uri={redirectURL}을 통해 code값 받아오기")
     @ApiResponses(value = {

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "소셜 로그인")
 @RequiredArgsConstructor
@@ -22,7 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class OauthController {
     private final OauthService oauthService;
 
-    @Operation(summary = "소셜 로그인", description = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=47fe7aff98cf882892387fe4b65d3279&redirect_uri={redirectURL}을 통해 code값 받아오기")
+    @GetMapping("/")
+
+    @Operation(summary = "소셜 로그인", description = "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL}을 통해 code값 받아오기, " +
+                                                    "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&state={state}&redirect_uri={redirectURL}을 통해 code값 받아오기")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "로그인 성공"),
             @ApiResponse(responseCode = "COMMON400", description = "처리할 수 없는 소셜 로그인")}

--- a/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
+++ b/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
@@ -2,7 +2,6 @@ package com.pitchain.dto.req;
 
 import com.pitchain.common.constant.OauthProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -20,8 +19,4 @@ public class OauthLoginReq {
     @NotBlank
     @Schema(description = "OAuth Provider Server로 부터 받은 인증 코드")
     private String code;
-
-    @Nullable
-    @Schema(description = "code 값 받아올 때 입력한 임의의 state 값, NAVER에만 쓰임", example = "STATE_STRING", nullable = true)
-    private String state;
 }

--- a/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
+++ b/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
@@ -22,6 +22,6 @@ public class OauthLoginReq {
     private String code;
 
     @Nullable
-    @Schema(description = "애플리케이션에서 생성한 임의의 상태 토큰값, NAVER에만 쓰임", example = "STATE_STRING", nullable = true)
+    @Schema(description = "code 값 받아올 때 입력한 임의의 state 값, NAVER에만 쓰임", example = "STATE_STRING", nullable = true)
     private String state;
 }

--- a/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
+++ b/src/main/java/com/pitchain/dto/req/OauthLoginReq.java
@@ -2,6 +2,7 @@ package com.pitchain.dto.req;
 
 import com.pitchain.common.constant.OauthProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -13,10 +14,14 @@ import lombok.Setter;
 @NoArgsConstructor
 public class OauthLoginReq {
     @NotNull
-    @Schema(description = "소셜 로그인 제공자", examples = {"KAKAO", "GOOGLE", "APPLE"})
+    @Schema(description = "소셜 로그인 제공자", examples = {"KAKAO", "GOOGLE", "NAVER"})
     private OauthProvider oauthProvider;
 
     @NotBlank
     @Schema(description = "OAuth Provider Server로 부터 받은 인증 코드")
     private String code;
+
+    @Nullable
+    @Schema(description = "애플리케이션에서 생성한 임의의 상태 토큰값, NAVER에만 쓰임", example = "STATE_STRING", nullable = true)
+    private String state;
 }

--- a/src/main/java/com/pitchain/oauth2/client/NaverClient.java
+++ b/src/main/java/com/pitchain/oauth2/client/NaverClient.java
@@ -1,0 +1,90 @@
+package com.pitchain.oauth2.client;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.oauth2.member.NaverMemberInfo;
+import com.pitchain.oauth2.member.OauthMemberInfo;
+import com.pitchain.oauth2.param.OauthParams;
+import com.pitchain.oauth2.token.NaverToken;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class NaverClient implements OauthClient {
+    @Value("${oauth.naver.token_url}")
+    private String token_url;
+    @Value("${oauth.naver.user_url}")
+    private String user_url;
+    @Value("${oauth.naver.grant_type}")
+    private String grant_type;
+    @Value("${oauth.naver.client_id}")
+    private String client_id;
+    @Value("${oauth.naver.client_secret}")
+    private String client_secret;
+    @Value("${oauth.naver.redirect_uri}")
+    private String redirect_uri;
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.NAVER;
+    }
+
+    @Override
+    public String getOauthLoginToken(OauthParams oauthParams) {
+        String url = token_url;
+        log.debug("Authorization code: " + oauthParams.getAuthorizationCode());
+
+        RestTemplate rt = new RestTemplate();
+        //헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        //바디 생성
+        MultiValueMap<String, String> body = oauthParams.makeBody();
+        body.add("grant_type", grant_type);
+        body.add("client_id", client_id);
+        body.add("client_secret", client_secret);
+        body.add("redirect_uri", redirect_uri);
+
+        //헤더 + 바디
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(body, headers);
+        log.debug("Current httpEntity state: " + tokenRequest);
+
+        //소셜토큰 수신
+        NaverToken naverToken = rt.postForObject(url, tokenRequest, NaverToken.class);
+        log.debug("accessToken: " + naverToken);
+
+        if (naverToken == null) {
+            log.error("naver token을 정상적으로 가져오지 못했습니다.");
+            throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        }
+        return naverToken.getAccess_token();
+    }
+
+    @Override
+    public OauthMemberInfo getMemberInfo(String accessToken) {
+        String url = user_url;
+
+        // 요청 객체 생성
+        RestTemplate rt = new RestTemplate();
+
+        // 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        // Naver 사용자 정보 요청 시 바디는 필요 없음
+        HttpEntity<String> memberInfoRequest = new HttpEntity<>(headers);
+
+        return rt.postForObject(url, memberInfoRequest, NaverMemberInfo.class);
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/member/NaverMemberInfo.java
+++ b/src/main/java/com/pitchain/oauth2/member/NaverMemberInfo.java
@@ -1,0 +1,40 @@
+package com.pitchain.oauth2.member;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pitchain.common.constant.OauthProvider;
+import lombok.Getter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverMemberInfo implements OauthMemberInfo {
+    @JsonProperty("response")
+    private Response response;
+
+    @Override
+    public String getSocialId() {
+        return response.id;
+    }
+
+    @Override
+    public String getEmail() {
+        return response.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return response.nickname;
+    }
+
+    @Override
+    public OauthProvider getOauthProvider() {
+        return OauthProvider.NAVER;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Response {
+        private String id;
+        private String nickname;
+        private String email;
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/param/NaverParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/NaverParams.java
@@ -29,7 +29,7 @@ public class NaverParams implements OauthParams {
     public MultiValueMap<String, String> makeBody() {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("code", authorizationCode);
-        body.add("sate", state);
+        body.add("state", state);
         return body;
     }
 }

--- a/src/main/java/com/pitchain/oauth2/param/NaverParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/NaverParams.java
@@ -10,7 +10,6 @@ import org.springframework.util.MultiValueMap;
 @AllArgsConstructor
 public class NaverParams implements OauthParams {
     private String authorizationCode;
-    private String state;
     @Override
     public OauthProvider oauthProvider() {
         return OauthProvider.NAVER;
@@ -21,15 +20,10 @@ public class NaverParams implements OauthParams {
         return authorizationCode;
     }
 
-    public String getState() {
-        return state;
-    }
-
     @Override
     public MultiValueMap<String, String> makeBody() {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("code", authorizationCode);
-        body.add("state", state);
         return body;
     }
 }

--- a/src/main/java/com/pitchain/oauth2/param/NaverParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/NaverParams.java
@@ -1,0 +1,35 @@
+package com.pitchain.oauth2.param;
+
+import com.pitchain.common.constant.OauthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@AllArgsConstructor
+public class NaverParams implements OauthParams {
+    private String authorizationCode;
+    private String state;
+    @Override
+    public OauthProvider oauthProvider() {
+        return OauthProvider.NAVER;
+    }
+
+    @Override
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        body.add("sate", state);
+        return body;
+    }
+}

--- a/src/main/java/com/pitchain/oauth2/param/OauthParams.java
+++ b/src/main/java/com/pitchain/oauth2/param/OauthParams.java
@@ -1,6 +1,5 @@
 package com.pitchain.oauth2.param;
 
-
 import com.pitchain.common.constant.OauthProvider;
 import org.springframework.util.MultiValueMap;
 

--- a/src/main/java/com/pitchain/oauth2/token/NaverToken.java
+++ b/src/main/java/com/pitchain/oauth2/token/NaverToken.java
@@ -1,0 +1,11 @@
+package com.pitchain.oauth2.token;
+
+import lombok.Data;
+
+@Data
+public class NaverToken {
+    private String access_token;
+    private String refresh_token;
+    private String token_type;
+    private int expires_in;
+}

--- a/src/main/java/com/pitchain/service/OauthService.java
+++ b/src/main/java/com/pitchain/service/OauthService.java
@@ -40,7 +40,7 @@ public class OauthService {
 
     private static OauthParams createOauthParams(OauthLoginReq req) {
         OauthProvider oauthProvider = req.getOauthProvider();
-        OauthParams oauthParam = oauthProvider.getOauthParams(req.getCode());
+        OauthParams oauthParam = oauthProvider.getOauthParams(req.getCode(), req.getState());
         return oauthParam;
     }
 

--- a/src/main/java/com/pitchain/service/OauthService.java
+++ b/src/main/java/com/pitchain/service/OauthService.java
@@ -40,7 +40,7 @@ public class OauthService {
 
     private static OauthParams createOauthParams(OauthLoginReq req) {
         OauthProvider oauthProvider = req.getOauthProvider();
-        OauthParams oauthParam = oauthProvider.getOauthParams(req);
+        OauthParams oauthParam = oauthProvider.getOauthParams(req.getCode());
         return oauthParam;
     }
 

--- a/src/main/java/com/pitchain/service/OauthService.java
+++ b/src/main/java/com/pitchain/service/OauthService.java
@@ -40,7 +40,7 @@ public class OauthService {
 
     private static OauthParams createOauthParams(OauthLoginReq req) {
         OauthProvider oauthProvider = req.getOauthProvider();
-        OauthParams oauthParam = oauthProvider.getOauthParams(req.getCode(), req.getState());
+        OauthParams oauthParam = oauthProvider.getOauthParams(req);
         return oauthParam;
     }
 


### PR DESCRIPTION
## ⭐ Summary

> #134 

<br>

## 📌 Tasks

1. 네이버 로그인 구현

<br>

## ETC
https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&redirect_uri=http://localhost:8080

1. 위 링크 접속 후 네이버 로그인
2. Redirect URL의  쿼리파라미터에서 code 값 조회
3. /oauth2/login에 바디 채워서 전송
    ```
    {
      "oauthProvider": "NAVER",
      "code": "{code}"
    }
    ```

네이버 로그인을 실사용하려면 검수 요청을 해야 해서 그전까지는 테스트 아이디를 개별적으로 등록해야 테스트 가능합니다.
네이버 id 알려주시면 등록하겠습니다!