### PR TITLE
[refactor] sp 조회 api 무한스크롤 적용

### DIFF
--- a/src/main/java/com/pitchain/common/entity/InfinityScrollRes.java
+++ b/src/main/java/com/pitchain/common/entity/InfinityScrollRes.java
@@ -1,0 +1,25 @@
+package com.pitchain.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@ToString
+@AllArgsConstructor
+public class InfinityScrollRes<T> {
+    @Getter
+    private List<T> content;
+    @Getter
+    private Long lastElementId;
+    private boolean hasNext;
+
+    public static <T> InfinityScrollRes<T> createRes(List<T> data, Long lastElementId, boolean hasNext) {
+        return new InfinityScrollRes<>(data, lastElementId, hasNext);
+    }
+
+    public boolean hasNext() {
+        return hasNext;
+    }
+}

--- a/src/main/java/com/pitchain/common/util/InfinityScrollUtil.java
+++ b/src/main/java/com/pitchain/common/util/InfinityScrollUtil.java
@@ -1,0 +1,18 @@
+package com.pitchain.common.util;
+
+import java.util.List;
+import java.util.Optional;
+
+public class InfinityScrollUtil {
+    public static <T> Optional<T> getLastElement(List<T> content) {
+        if (content.isEmpty()) return Optional.empty();
+
+        T t = content.get(content.size() - 1);
+
+        return Optional.ofNullable(t);
+    }
+
+    public static boolean hasNext(int contentSize, int pageSize) {
+        return contentSize > pageSize;
+    }
+}

--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -1,6 +1,7 @@
 package com.pitchain.controller;
 
 import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.common.entity.InfinityScrollRes;
 import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.service.SpService;
@@ -36,11 +37,13 @@ public class SpController {
         return CustomApiResponse.onSuccess(spDetailResList);
     }
 
-    @Operation(summary = "카테고리별 SP 리스트 조회")
+    @Operation(summary = "카테고리별 SP 리스트 조회", description = "첫 조회 시 쿼리 파라미터에 lastSpId를 포함시키지 않습니다.")
     @GetMapping("/category")
-    public CustomApiResponse<List<SpDetailRes>> getSpDetailsFilteredCategory(@AuthenticationPrincipal Long memberId,
-                                                                             @RequestParam String mainCategoryInKorean) {
-        List<SpDetailRes> spDetailResList = spService.getSpDetailsFilteredCategory(memberId, mainCategoryInKorean);
+    public CustomApiResponse<InfinityScrollRes<SpDetailRes>> getSpDetailsFilteredCategory(@AuthenticationPrincipal Long memberId,
+                                                                                          @RequestParam String mainCategoryInKorean,
+                                                                                          @RequestParam(required = false) Long lastSpId,
+                                                                                          @RequestParam(defaultValue = "10") int size) {
+        InfinityScrollRes<SpDetailRes> spDetailResList = spService.getSpDetailsFilteredCategory(memberId, mainCategoryInKorean, lastSpId, size);
         return CustomApiResponse.onSuccess(spDetailResList);
     }
 

--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -47,13 +47,7 @@ public class SpController {
         return CustomApiResponse.onSuccess(spDetailRes);
     }
 
-    @GetMapping("/recommendation")
-    public CustomApiResponse<List<SpDetailRes>> getSpDetailsRecommendedFromAi(@AuthenticationPrincipal Long memberId,
-                                                                              @RequestParam List<Long> bmIds) {
-        List<SpDetailRes> spDetailResList = spService.getSpDetailsRecommendedFromAi(memberId, bmIds);
-        return CustomApiResponse.onSuccess(spDetailResList);
-    }
-
+    @Operation(summary = "SP 수정")
     @PutMapping(value = "/{spId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CustomApiResponse updateSp(@AuthenticationPrincipal Long companyId,
                                       @PathVariable Long spId,

--- a/src/main/java/com/pitchain/controller/SpController.java
+++ b/src/main/java/com/pitchain/controller/SpController.java
@@ -4,6 +4,7 @@ import com.pitchain.common.apiPayload.dto.CustomApiResponse;
 import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.service.SpService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import java.util.List;
 public class SpController {
     private final SpService spService;
 
+    @Operation(summary = "SP 생성")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CustomApiResponse createSp(@AuthenticationPrincipal Long companyId,
                                       @RequestPart CreateSpReq createSpReq,
@@ -27,12 +29,14 @@ public class SpController {
         return CustomApiResponse.onSuccess();
     }
 
+    @Operation(summary = "SP 리스트 조회")
     @GetMapping
     public CustomApiResponse<List<SpDetailRes>> getSpDetails(@AuthenticationPrincipal Long memberId) {
         List<SpDetailRes> spDetailResList = spService.getSpDetails(memberId);
         return CustomApiResponse.onSuccess(spDetailResList);
     }
 
+    @Operation(summary = "카테고리별 SP 리스트 조회")
     @GetMapping("/category")
     public CustomApiResponse<List<SpDetailRes>> getSpDetailsFilteredCategory(@AuthenticationPrincipal Long memberId,
                                                                              @RequestParam String mainCategoryInKorean) {
@@ -40,6 +44,7 @@ public class SpController {
         return CustomApiResponse.onSuccess(spDetailResList);
     }
 
+    @Operation(summary = "SP 상세 조회")
     @GetMapping("/{spId}")
     public CustomApiResponse<SpDetailRes> getSpDetail(@AuthenticationPrincipal Long memberId,
                                                       @PathVariable Long spId) {
@@ -58,6 +63,7 @@ public class SpController {
         return CustomApiResponse.onSuccess();
     }
 
+    @Operation(summary = "SP 삭제")
     @DeleteMapping("/{spId}")
     public CustomApiResponse deleteSp(@AuthenticationPrincipal Long companyId,
                                       @PathVariable Long spId) {

--- a/src/main/java/com/pitchain/repository/SpRepositoryCustom.java
+++ b/src/main/java/com/pitchain/repository/SpRepositoryCustom.java
@@ -20,7 +20,7 @@ public class SpRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<SpWithLikeDto> getSpWithLikeDtoFilteredCategory(Long memberId, MainCategory category) {
+    public List<SpWithLikeDto> getSpWithLikeDtoFilteredCategory(Long memberId, MainCategory category, Long lastSpId, int size) {
         return queryFactory
                 .select(new QSpWithLikeDto(
                         sp,
@@ -29,12 +29,21 @@ public class SpRepositoryCustom {
                 .from(sp)
                 .leftJoin(sp.bm, bm)
                 .leftJoin(spLike).on(spLike.sp.id.eq(sp.id).and(spLike.member.id.eq(memberId)))
-                .where(eqMainCategory(category))
+                .where(
+                        eqMainCategory(category),
+                        ltSpId(lastSpId)
+                )
+                .orderBy(sp.id.desc())
+                .limit(size + 1)
                 .distinct()
                 .fetch();
     }
 
     private static BooleanExpression eqMainCategory(MainCategory category) {
         return bm.mainCategory.eq(category);
+    }
+
+    private BooleanExpression ltSpId(Long lastSpId) {
+        return lastSpId == null ? null : sp.id.lt(lastSpId);
     }
 }

--- a/src/main/java/com/pitchain/service/SpService.java
+++ b/src/main/java/com/pitchain/service/SpService.java
@@ -4,11 +4,16 @@ import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import com.pitchain.common.constant.MainCategory;
 import com.pitchain.common.constant.S3UploadTarget;
 import com.pitchain.common.constant.SubCategory;
+import com.pitchain.common.entity.InfinityScrollRes;
 import com.pitchain.common.exception.GeneralHandler;
+import com.pitchain.common.util.InfinityScrollUtil;
 import com.pitchain.dto.SpWithLikeDto;
 import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
-import com.pitchain.entity.*;
+import com.pitchain.entity.Bm;
+import com.pitchain.entity.CategoryPref;
+import com.pitchain.entity.Company;
+import com.pitchain.entity.Sp;
 import com.pitchain.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Transactional
 @RequiredArgsConstructor
@@ -66,11 +72,18 @@ public class SpService {
     }
 
     @Transactional(readOnly = true)
-    public List<SpDetailRes> getSpDetailsFilteredCategory(Long memberId, String mainCategoryInKorean) {
+    public InfinityScrollRes<SpDetailRes> getSpDetailsFilteredCategory(Long memberId, String mainCategoryInKorean, Long lastSpId, int size) {
         MainCategory mainCategory = MainCategory.from(mainCategoryInKorean);
-        List<SpWithLikeDto> spWithLikeDtos = spRepositoryCustom.getSpWithLikeDtoFilteredCategory(memberId, mainCategory);
 
-        return spWithLikeDtos.stream()
+        List<SpWithLikeDto> spWithLikeDtos = spRepositoryCustom.getSpWithLikeDtoFilteredCategory(memberId, mainCategory, lastSpId, size);
+
+        boolean hasNext = InfinityScrollUtil.hasNext(spWithLikeDtos.size(), size);
+        if (hasNext)
+            spWithLikeDtos.remove(spWithLikeDtos.size() - 1);
+        Optional<SpWithLikeDto> lastElement = InfinityScrollUtil.getLastElement(spWithLikeDtos);
+        Long lastElementId = lastElement.map(spWithLikeDto -> spWithLikeDto.getSp().getId()).orElse(null);
+
+        List<SpDetailRes> content = spWithLikeDtos.stream()
                 .map(spWithLikeDto -> {
                     Sp sp = spWithLikeDto.getSp();
                     String spURL = s3Service.getFileURL(sp.getSpKey());
@@ -86,6 +99,8 @@ public class SpService {
                     return SpDetailRes.createRes(company, logoImgURL, spWithLikeDto, spURL, thumbnailImgURL, likeCnt, subCategories);
                 })
                 .toList();
+
+        return InfinityScrollRes.createRes(content, lastElementId, hasNext);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/pitchain/service/SpServiceTest.java
+++ b/src/test/java/com/pitchain/service/SpServiceTest.java
@@ -4,6 +4,7 @@ import com.pitchain.common.constant.Country;
 import com.pitchain.common.constant.MainCategory;
 import com.pitchain.common.constant.S3UploadTarget;
 import com.pitchain.common.constant.SubCategory;
+import com.pitchain.common.entity.InfinityScrollRes;
 import com.pitchain.dto.req.CreateSpReq;
 import com.pitchain.dto.res.SpDetailRes;
 import com.pitchain.entity.*;
@@ -206,24 +207,33 @@ class SpServiceTest {
         spLikeRepository.save(new SpLike(member2, sp1));
 
         //when
-        List<SpDetailRes> spDetails = spService.getSpDetailsFilteredCategory(member1.getId(), MainCategory.TECH_DIGITAL.getKoreanName());
+        InfinityScrollRes<SpDetailRes> spDetailRes_1 = spService.getSpDetailsFilteredCategory(
+                member1.getId(), MainCategory.TECH_DIGITAL.getKoreanName(), null, 1);
+        InfinityScrollRes<SpDetailRes> spDetailRes_2 = spService.getSpDetailsFilteredCategory(
+                member1.getId(), MainCategory.TECH_DIGITAL.getKoreanName(), spDetailRes_1.getLastElementId(), 1);
 
         // then
-        assertThat(spDetails).hasSize(2);
+        List<SpDetailRes> content_1 = spDetailRes_1.getContent();
+        SpDetailRes spDetailRes = content_1.get(0); // sp2 조회 결과
+        assertThat(spDetailRes.bmId()).isEqualTo(sp2.getBm().getId());
+        assertThat(content_1.get(0).mainCategory()).isEqualTo(bm1.getMainCategory().getKoreanName());
+        assertThat(content_1.get(0).name()).isEqualTo(sp1.getName());
+        assertThat(content_1.get(0).views()).isEqualTo(sp1.getViews());
+        assertThat(content_1.get(0).isLiked()).isFalse();
+        assertThat(content_1.get(0).likeCnt()).isEqualTo(0);
+        assertThat(spDetailRes_1.hasNext()).isTrue();
+        assertThat(spDetailRes_1.getLastElementId()).isEqualTo(sp2.getId());
 
-        assertThat(spDetails.get(0).bmId()).isEqualTo(bm1.getId());
-        assertThat(spDetails.get(0).mainCategory()).isEqualTo(bm1.getMainCategory().getKoreanName());
-        assertThat(spDetails.get(0).name()).isEqualTo(sp1.getName());
-        assertThat(spDetails.get(0).views()).isEqualTo(sp1.getViews());
-        assertThat(spDetails.get(0).isLiked()).isTrue();
-        assertThat(spDetails.get(0).likeCnt()).isEqualTo(2);
-
-        assertThat(spDetails.get(1).bmId()).isEqualTo(bm2.getId());
-        assertThat(spDetails.get(1).mainCategory()).isEqualTo(bm2.getMainCategory().getKoreanName());
-        assertThat(spDetails.get(1).name()).isEqualTo(sp2.getName());
-        assertThat(spDetails.get(1).views()).isEqualTo(sp2.getViews());
-        assertThat(spDetails.get(1).isLiked()).isFalse();
-        assertThat(spDetails.get(1).likeCnt()).isEqualTo(0);
+        List<SpDetailRes> content_2 = spDetailRes_2.getContent();
+        spDetailRes = content_2.get(0); // sp1 조회 결과
+        assertThat(spDetailRes.bmId()).isEqualTo(sp1.getBm().getId());
+        assertThat(spDetailRes.mainCategory()).isEqualTo(bm1.getMainCategory().getKoreanName());
+        assertThat(spDetailRes.name()).isEqualTo(sp1.getName());
+        assertThat(spDetailRes.views()).isEqualTo(sp1.getViews());
+        assertThat(spDetailRes.isLiked()).isTrue();
+        assertThat(spDetailRes.likeCnt()).isEqualTo(2);
+        assertThat(spDetailRes_2.hasNext()).isFalse();
+        assertThat(spDetailRes_2.getLastElementId()).isEqualTo(sp1.getId());
     }
 
     @Test


### PR DESCRIPTION
## ⭐ Summary

> #135 

<br>

## 📌 Tasks

1. 기존 sp 조회에 무한 스크롤 적용

<br>

## ETC
추후 다른 api에 무한스크롤을 적용을 고려하여 최대한 재사용성을 고려하여 개발하려고 했습니다.
다만, hasNext 체크 -> content 삭제 -> lastElementId 조회 이 순서가 유지되어야 하고, content도 response로 후처리하는 작업이 필요한 경우를 모두 고려하려고 하니 생각보다 만족스러운 코드는 아니네요. 더 좋은 방법 있으면 피드백 주십쇼!