### PR TITLE
[refactor] 프론트 요청 처리

### DIFF
--- a/src/main/java/com/pitchain/common/apiPayload/annotation/ErrorApiResponse.java
+++ b/src/main/java/com/pitchain/common/apiPayload/annotation/ErrorApiResponse.java
@@ -1,0 +1,14 @@
+package com.pitchain.common.apiPayload.annotation;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ErrorApiResponse {
+    ErrorStatus value();
+}

--- a/src/main/java/com/pitchain/common/apiPayload/annotation/ErrorApiResponses.java
+++ b/src/main/java/com/pitchain/common/apiPayload/annotation/ErrorApiResponses.java
@@ -1,0 +1,14 @@
+package com.pitchain.common.apiPayload.annotation;
+
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ErrorApiResponses {
+    ErrorStatus[] value();
+}

--- a/src/main/java/com/pitchain/common/config/SwaggerConfig.java
+++ b/src/main/java/com/pitchain/common/config/SwaggerConfig.java
@@ -1,12 +1,19 @@
 package com.pitchain.common.config;
 
+import com.pitchain.common.apiPayload.annotation.ErrorApiResponse;
+import com.pitchain.common.apiPayload.annotation.ErrorApiResponses;
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,4 +56,42 @@ public class SwaggerConfig {
                 .version("v0.0.1");
     }
 
+    @Bean
+    public OperationCustomizer customizeResponses() {
+        return (operation, handlerMethod) -> {
+            processErrorApiResponse(operation, handlerMethod.getMethodAnnotation(ErrorApiResponse.class));
+            processErrorApiResponses(operation, handlerMethod.getMethodAnnotation(ErrorApiResponses.class));
+            return operation;
+        };
+    }
+
+    private void processErrorApiResponse(Operation operation, ErrorApiResponse errorApiResponse) {
+        if (errorApiResponse != null) {
+            addErrorResponse(operation.getResponses(), errorApiResponse.value());
+        }
+    }
+
+    private void processErrorApiResponses(Operation operation, ErrorApiResponses errorApiResponses) {
+        if (errorApiResponses != null) {
+            ApiResponses responses = operation.getResponses();
+            for (ErrorStatus errorStatus : errorApiResponses.value()) {
+                addErrorResponse(responses, errorStatus);
+            }
+        }
+    }
+
+    private void addErrorResponse(ApiResponses responses, ErrorStatus errorStatus) {
+        String code = errorStatus.getCode();
+        String description = errorStatus.getMessage();
+        Content errorContent = new Content().addMediaType("application/json", new MediaType().schema(
+                new Schema<>()
+                        .type("object")
+                        .addProperty("isSuccess", new BooleanSchema()._default(false))
+                        .addProperty("code", new StringSchema()._default(code))
+                        .addProperty("message", new StringSchema()._default(description))
+        ));
+        responses.put(code, new io.swagger.v3.oas.models.responses.ApiResponse()
+                .description(description)
+                .content(errorContent));
+    }
 }

--- a/src/main/java/com/pitchain/controller/MemberController.java
+++ b/src/main/java/com/pitchain/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.pitchain.controller;
+
+import com.pitchain.common.apiPayload.annotation.ErrorApiResponse;
+import com.pitchain.common.apiPayload.dto.CustomApiResponse;
+import com.pitchain.common.apiPayload.statusEnums.ErrorStatus;
+import com.pitchain.dto.res.MemberDetailRes;
+import com.pitchain.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@RestController
+public class MemberController {
+    private final MemberService memberService;
+
+    @Operation(summary = "나의 정보 조회")
+    @ErrorApiResponse(ErrorStatus.MEMBER_NOT_FOUND)
+    @GetMapping
+    public CustomApiResponse<MemberDetailRes> getMyDetail(@AuthenticationPrincipal Long memberId) {
+        MemberDetailRes memberDetailRes = memberService.getMyDetail(memberId);
+        return CustomApiResponse.onSuccess(memberDetailRes);
+    }
+}

--- a/src/main/java/com/pitchain/controller/MemberController.java
+++ b/src/main/java/com/pitchain/controller/MemberController.java
@@ -8,9 +8,7 @@ import com.pitchain.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/members")
@@ -24,5 +22,12 @@ public class MemberController {
     public CustomApiResponse<MemberDetailRes> getMyDetail(@AuthenticationPrincipal Long memberId) {
         MemberDetailRes memberDetailRes = memberService.getMyDetail(memberId);
         return CustomApiResponse.onSuccess(memberDetailRes);
+    }
+
+    @Operation(summary = "Access Token 재발급")
+    @PostMapping
+    public CustomApiResponse<String> reissueAccessToken(@RequestParam String refreshToken) {
+        String accessToken = memberService.reissueAccessToken(refreshToken);
+        return CustomApiResponse.onSuccess(accessToken);
     }
 }

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -22,7 +22,7 @@ public class OauthController {
     @Operation(summary = "소셜 로그인", description = "각 Oauth 플랫폼의 endpoint를 통해 code값  조회 후 api 호출 <br>" +
             "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL} <br> " +
             "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&redirect_uri={redirectURL} <br> " +
-            "GOOGLE: https://accounts.google.com/o/oauth2/v2/auth?client_id=936222247413-8cojftn1k2kipmrgspo9glprk5drrt3t.apps.googleusercontent.com&redirect_uri=http://localhost:8080&response_type=code&scope=email%20profile"
+            "GOOGLE: https://accounts.google.com/o/oauth2/v2/auth?client_id=936222247413-8cojftn1k2kipmrgspo9glprk5drrt3t.apps.googleusercontent.com&redirect_uri={redirectURL}&response_type=code&scope=email%20profile"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "로그인 성공"),

--- a/src/main/java/com/pitchain/controller/OauthController.java
+++ b/src/main/java/com/pitchain/controller/OauthController.java
@@ -19,8 +19,11 @@ import org.springframework.web.bind.annotation.*;
 public class OauthController {
     private final OauthService oauthService;
 
-    @Operation(summary = "소셜 로그인", description = "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL}을 통해 code값 받아오기, " +
-                                                    "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&redirect_uri={redirectURL}을 통해 code값 받아오기")
+    @Operation(summary = "소셜 로그인", description = "각 Oauth 플랫폼의 endpoint를 통해 code값  조회 후 api 호출 <br>" +
+            "KAKAO: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=891063e7c569324189a0353dfb18c534&redirect_uri={redirectURL} <br> " +
+            "NAVER: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=T4z00JRW0P38KpqrIc6w&redirect_uri={redirectURL} <br> " +
+            "GOOGLE: https://accounts.google.com/o/oauth2/v2/auth?client_id=936222247413-8cojftn1k2kipmrgspo9glprk5drrt3t.apps.googleusercontent.com&redirect_uri=http://localhost:8080&response_type=code&scope=email%20profile"
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "로그인 성공"),
             @ApiResponse(responseCode = "COMMON400", description = "처리할 수 없는 소셜 로그인")}

--- a/src/main/java/com/pitchain/dto/res/MemberDetailRes.java
+++ b/src/main/java/com/pitchain/dto/res/MemberDetailRes.java
@@ -1,0 +1,22 @@
+package com.pitchain.dto.res;
+
+import com.pitchain.common.constant.OauthProvider;
+import com.pitchain.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberDetailRes(
+        String profileImgURL,
+        String nickname,
+        String email,
+        OauthProvider oauthProvider
+) {
+    public static MemberDetailRes createRes(Member member, String profileImgURL) {
+        return MemberDetailRes.builder()
+                .profileImgURL(profileImgURL)
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .oauthProvider(member.getOauthProvider())
+                .build();
+    }
+}

--- a/src/main/java/com/pitchain/service/MemberService.java
+++ b/src/main/java/com/pitchain/service/MemberService.java
@@ -2,6 +2,7 @@ package com.pitchain.service;
 
 import com.pitchain.dto.res.MemberDetailRes;
 import com.pitchain.entity.Member;
+import com.pitchain.jwt.TokenUtil;
 import com.pitchain.repository.EntityFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ public class MemberService {
 
     private final EntityFacade entityFacade;
     private final S3Service s3Service;
+    private final TokenUtil tokenUtil;
 
     public MemberDetailRes getMyDetail(Long memberId) {
         Member member = entityFacade.getMember(memberId);
@@ -21,5 +23,9 @@ public class MemberService {
         String profileImgURL = s3Service.getFileURL(member.getProfileImgKey());
 
         return MemberDetailRes.createRes(member, profileImgURL);
+    }
+
+    public String reissueAccessToken(String refreshToken) {
+        return tokenUtil.reissueAccessToken(refreshToken);
     }
 }

--- a/src/main/java/com/pitchain/service/MemberService.java
+++ b/src/main/java/com/pitchain/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.pitchain.service;
+
+import com.pitchain.dto.res.MemberDetailRes;
+import com.pitchain.entity.Member;
+import com.pitchain.repository.EntityFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final EntityFacade entityFacade;
+    private final S3Service s3Service;
+
+    public MemberDetailRes getMyDetail(Long memberId) {
+        Member member = entityFacade.getMember(memberId);
+
+        String profileImgURL = s3Service.getFileURL(member.getProfileImgKey());
+
+        return MemberDetailRes.createRes(member, profileImgURL);
+    }
+}

--- a/src/test/java/com/pitchain/service/MemberServiceTest.java
+++ b/src/test/java/com/pitchain/service/MemberServiceTest.java
@@ -1,0 +1,53 @@
+package com.pitchain.service;
+
+import com.pitchain.common.constant.Country;
+import com.pitchain.dto.res.MemberDetailRes;
+import com.pitchain.entity.Member;
+import com.pitchain.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private S3Service s3Service;
+
+    private Member saveMember() {
+        return memberRepository.save(new Member(Country.USA, "profileImg.jpg"));
+    }
+
+    @Test
+    void 내_정보_조회_성공() {
+        //given
+        Member member = saveMember();
+
+        //when
+        MemberDetailRes memberDetailRes = memberService.getMyDetail(member.getId());
+        String profileImgURL = s3Service.getFileURL(member.getProfileImgKey());
+
+        //then
+        List<Member> members = memberRepository.findAll();
+        assertThat(members.size()).isEqualTo(1);
+
+        Member findMember = members.get(0);
+        assertThat(memberDetailRes.profileImgURL()).isEqualTo(profileImgURL);
+        assertThat(memberDetailRes.nickname()).isEqualTo(findMember.getNickname());
+        assertThat(memberDetailRes.email()).isEqualTo(findMember.getEmail());
+        assertThat(memberDetailRes.oauthProvider()).isEqualTo(findMember.getOauthProvider());
+
+    }
+}


### PR DESCRIPTION
## ⭐ Summary

> #151 

<br>

## 📌 Tasks

1. 프론트에서 요청한 내용 처리
2. Swagger 에러 응답 자동화 기능 구현

<br>

## ETC
@Response, @Responses를 통해 데이터 다 채워주는 번거로움 없이, @ErrorApiResponse(ErrorStatus.~~)을 통해 처리 가능합니다.

성공 response는 (@Response, @Responses)를 선언하지 않았다면 swagger에서 자동으로 return 값 바인딩해서 처리해줘서 따로 안 만들었습니다
