### PR TITLE
[refactor] 서비스 로직의 책임 분리 및 양방향 관계 제거

### DIFF
--- a/src/main/java/com/pitchain/entity/Bm.java
+++ b/src/main/java/com/pitchain/entity/Bm.java
@@ -1,15 +1,12 @@
 package com.pitchain.entity;
 
 import com.pitchain.common.constant.MainCategory;
-import com.pitchain.common.constant.SubCategory;
 import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/pitchain/entity/Comment.java
+++ b/src/main/java/com/pitchain/entity/Comment.java
@@ -3,12 +3,8 @@ package com.pitchain.entity;
 import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -32,21 +28,22 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment")
-    private List<Comment> childComments = new ArrayList<>();
-
     @Column(nullable = false)
     private String content;
 
     @Column(name = "del_yn")
     private boolean delYN;
 
-    @Builder
-    public Comment(Member member, Bm bm, Comment parentComment, String content) {
-        this.member = member;
-        this.bm = bm;
+    public static Comment of(Member member, Bm bm, String content) {
+        Comment comment = new Comment();
+        comment.member = member;
+        comment.bm = bm;
+        comment.content = content;
+        return comment;
+    }
+
+    public void setParent(Comment parentComment) {
         this.parentComment = parentComment;
-        this.content = content;
     }
 
     public void deleteParentComment() {

--- a/src/main/java/com/pitchain/entity/Investment.java
+++ b/src/main/java/com/pitchain/entity/Investment.java
@@ -3,7 +3,6 @@ package com.pitchain.entity;
 import com.pitchain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,10 +27,11 @@ public class Investment  extends BaseEntity {
     @Column(nullable = false)
     private long amount;
 
-    @Builder
-    public Investment(Member member, Bm bm, long amount) {
-        this.member = member;
-        this.bm = bm;
-        this.amount = amount;
+    public static Investment of(Member member, Bm bm, long amount) {
+        Investment investment = new Investment();
+        investment.member = member;
+        investment.bm = bm;
+        investment.amount = amount;
+        return investment;
     }
 }

--- a/src/main/java/com/pitchain/repository/CommentRepository.java
+++ b/src/main/java/com/pitchain/repository/CommentRepository.java
@@ -16,11 +16,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "AND c.bm = :bm")
     List<Comment> findAllByBm(@Param("bm") Bm bm);
 
-    @Query("SELECT c From Comment c " +
-            "LEFT JOIN FETCH c.member " +
-            "WHERE c.parentComment IN :parentComments")
-    List<Comment> findAllByParentComments(@Param("parentComments") List<Comment> parentComments);
-
     List<Comment> findByParentComment(@Param("parentComment") Comment parentComment);
 
 }

--- a/src/main/java/com/pitchain/repository/CommentRepository.java
+++ b/src/main/java/com/pitchain/repository/CommentRepository.java
@@ -2,21 +2,25 @@ package com.pitchain.repository;
 
 import com.pitchain.entity.Bm;
 import com.pitchain.entity.Comment;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT DISTINCT c FROM Comment c " +
             "LEFT JOIN FETCH c.member " +
-            "LEFT JOIN FETCH c.childComments cc " +
-            "LEFT JOIN FETCH cc.member " +
             "WHERE c.parentComment IS NULL " +
             "AND c.bm = :bm")
-    List<Comment> findByBm(@Param("bm") Bm bm);
+    List<Comment> findAllByBm(@Param("bm") Bm bm);
+
+    @Query("SELECT c From Comment c " +
+            "LEFT JOIN FETCH c.member " +
+            "WHERE c.parentComment IN :parentComments")
+    List<Comment> findAllByParentComments(@Param("parentComments") List<Comment> parentComments);
+
+    List<Comment> findByParentComment(@Param("parentComment") Comment parentComment);
+
 }

--- a/src/main/java/com/pitchain/repository/CommentRepository.java
+++ b/src/main/java/com/pitchain/repository/CommentRepository.java
@@ -16,6 +16,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "AND c.bm = :bm")
     List<Comment> findAllByBm(@Param("bm") Bm bm);
 
+    @Query("SELECT c FROM Comment c " +
+           "LEFT JOIN FETCH c.member " +
+           "WHERE c.parentComment = :parentComment")
     List<Comment> findByParentComment(@Param("parentComment") Comment parentComment);
 
 }

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -11,9 +11,8 @@ import com.pitchain.entity.Bm;
 import com.pitchain.entity.Comment;
 import com.pitchain.entity.Member;
 import com.pitchain.jwt.MemberDetails;
-import com.pitchain.repository.BmRepository;
 import com.pitchain.repository.CommentRepository;
-import com.pitchain.repository.MemberRepository;
+import com.pitchain.repository.EntityFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,15 +24,12 @@ import java.util.List;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final BmRepository bmRepository;
-    private final MemberRepository memberRepository;
+    private final EntityFacade entityFacade;
 
     @Transactional
     public void addComment(Long bmId, MemberDetails memberDetails, CommentReq.AddCommentReq req) {
-        Member member = memberRepository.findById(memberDetails.id()).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        Bm bm = bmRepository.findById(bmId).orElseThrow(() ->
-                new GeneralException(ErrorStatus.BM_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
+        Bm bm = entityFacade.getBm(bmId);
 
         String content = req.getContent();
         Long parentCommentId = req.getParentCommentId();
@@ -71,10 +67,8 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<? extends BaseCommentRes> getComments(Long bmId, MemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.id()).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        Bm bm = bmRepository.findById(bmId).orElseThrow(() ->
-                new GeneralException(ErrorStatus.BM_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
+        Bm bm = entityFacade.getBm(bmId);
 
         List<Comment> comments = commentRepository.findByBm(bm);
 
@@ -96,8 +90,7 @@ public class CommentService {
 
     @Transactional
     public void modifyComment(Long commentId, MemberDetails memberDetails, CommentReq.ModifyCommentReq req) {
-        Member member = memberRepository.findById(memberDetails.id()).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
         Comment comment = commentRepository.findById(commentId).orElseThrow(() ->
                 new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
 
@@ -110,8 +103,7 @@ public class CommentService {
 
     @Transactional
     public void removeComment(Long commentId, MemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.id()).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
         Comment comment = commentRepository.findById(commentId).orElseThrow(() ->
                 new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
 

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -68,7 +68,7 @@ public class CommentService {
 
         return comments.stream()
                 .map(comment -> {
-                    List<ReplyCommentRes> replyCommentResList = commentRepository.findAllByParentComments(comments).stream()
+                    List<ReplyCommentRes> replyCommentResList = commentRepository.findByParentComment(comment).stream()
                             .map(childComment -> ReplyCommentRes.createRes(
                                     childComment, childComment.getMember().getProfileImgKey()
                             ))

--- a/src/main/java/com/pitchain/service/CommentService.java
+++ b/src/main/java/com/pitchain/service/CommentService.java
@@ -41,26 +41,20 @@ public class CommentService {
         }
     }
 
+    @Transactional
     private void addReplyComment(Member member, Bm bm, String content, Long parentCommentId) {
         Comment parentComment = commentRepository.findById(parentCommentId).orElseThrow(() ->
                 new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
 
-        Comment comment = Comment.builder()
-                .member(member)
-                .bm(bm)
-                .parentComment(parentComment)
-                .content(content)
-                .build();
+        Comment comment = Comment.of(member, bm, content);
+        comment.setParent(parentComment);
 
         commentRepository.save(comment);
     }
 
+    @Transactional
     private void addComment(Member member, Bm bm, String content) {
-        Comment comment = Comment.builder()
-                .member(member)
-                .bm(bm)
-                .content(content)
-                .build();
+        Comment comment = Comment.of(member, bm, content);
 
         commentRepository.save(comment);
     }
@@ -70,11 +64,11 @@ public class CommentService {
         Member member = entityFacade.getMember(memberDetails.id());
         Bm bm = entityFacade.getBm(bmId);
 
-        List<Comment> comments = commentRepository.findByBm(bm);
+        List<Comment> comments = commentRepository.findAllByBm(bm);
 
         return comments.stream()
                 .map(comment -> {
-                    List<ReplyCommentRes> replyCommentResList = comment.getChildComments().stream()
+                    List<ReplyCommentRes> replyCommentResList = commentRepository.findAllByParentComments(comments).stream()
                             .map(childComment -> ReplyCommentRes.createRes(
                                     childComment, childComment.getMember().getProfileImgKey()
                             ))
@@ -118,7 +112,7 @@ public class CommentService {
     }
 
     private boolean isReplyComment(Comment comment) {
-        List<Comment> childComments = comment.getChildComments();
+        List<Comment> childComments = commentRepository.findByParentComment(comment);
         return childComments.isEmpty();
     }
 

--- a/src/main/java/com/pitchain/service/InvestmentService.java
+++ b/src/main/java/com/pitchain/service/InvestmentService.java
@@ -29,11 +29,7 @@ public class InvestmentService {
 
         Member member = entityFacade.getMember(memberDetails.id());
         Bm bm = entityFacade.getBm(bmId);
-        Investment investment = Investment.builder()
-                .member(member)
-                .bm(bm)
-                .amount(amount)
-                .build();
+        Investment investment = Investment.of(member, bm, amount);
 
         investmentRepository.save(investment);
     }

--- a/src/main/java/com/pitchain/service/InvestmentService.java
+++ b/src/main/java/com/pitchain/service/InvestmentService.java
@@ -9,9 +9,8 @@ import com.pitchain.entity.Bm;
 import com.pitchain.entity.Investment;
 import com.pitchain.entity.Member;
 import com.pitchain.jwt.MemberDetails;
-import com.pitchain.repository.BmRepository;
+import com.pitchain.repository.EntityFacade;
 import com.pitchain.repository.InvestmentRepository;
-import com.pitchain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,17 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class InvestmentService {
 
     private final InvestmentRepository investmentRepository;
-    private final BmRepository bmRepository;
-    private final MemberRepository memberRepository;
+    private final EntityFacade entityFacade;
 
     public void addInvestment(Long bmId, MemberDetails memberDetails, long amount) {
         if (memberDetails.memberRole().equals(MemberRole.COMPANY))
             throw new GeneralException(ErrorStatus.COMPANY_FORBIDDEN);
 
-        Member member = memberRepository.findById(memberDetails.id())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-
-        Bm bm = bmRepository.findById(bmId).orElseThrow(() -> new GeneralException(ErrorStatus.BM_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
+        Bm bm = entityFacade.getBm(bmId);
         Investment investment = Investment.builder()
                 .member(member)
                 .bm(bm)
@@ -44,8 +40,7 @@ public class InvestmentService {
 
     @Transactional(readOnly = true)
     public InvestmentStatusRes getInvestmentStatus(Long bmId) {
-        Bm bm = bmRepository.findById(bmId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BM_NOT_FOUND));
+        Bm bm = entityFacade.getBm(bmId);
 
         InvestmentStatusDto investmentStatusDto = investmentRepository.findInvestmentStatusByBm(bm);
         int achievementRate = getAchievementRate(bm.getGoalInvestment(), investmentStatusDto.getRaisedAmount());

--- a/src/main/java/com/pitchain/service/MySpHistoryService.java
+++ b/src/main/java/com/pitchain/service/MySpHistoryService.java
@@ -1,13 +1,10 @@
 package com.pitchain.service;
 
-import com.pitchain.common.apiPayload.ErrorStatus;
-import com.pitchain.common.exception.GeneralException;
 import com.pitchain.entity.Bm;
 import com.pitchain.entity.Member;
 import com.pitchain.entity.MySpHistory;
 import com.pitchain.jwt.MemberDetails;
-import com.pitchain.repository.BmRepository;
-import com.pitchain.repository.MemberRepository;
+import com.pitchain.repository.EntityFacade;
 import com.pitchain.repository.MySpHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,15 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MySpHistoryService {
 
     private final MySpHistoryRepository mySpHistoryRepository;
-    private final MemberRepository memberRepository;
-    private final BmRepository bmRepository;
+    private final EntityFacade entityFacade;
 
     @Transactional
     public void saveMySpHistory(MemberDetails memberDetails, Long bmId, int viewTime) {
-        Member member = memberRepository.findById(memberDetails.id())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        Bm bm = bmRepository.findById(bmId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BM_NOT_FOUND));
+        Member member = entityFacade.getMember(memberDetails.id());
+        Bm bm = entityFacade.getBm(bmId);
 
         mySpHistoryRepository.findByMemberAndBm(member, bm)
                 .ifPresentOrElse(

--- a/src/test/java/com/pitchain/service/CommentServiceTest.java
+++ b/src/test/java/com/pitchain/service/CommentServiceTest.java
@@ -74,17 +74,16 @@ class CommentServiceTest {
         commentService.addComment(bm.getId(), individualMemberDetails, addCommentReq);
 
         //then
-        List<Comment> comments = commentRepository.findByBm(bm);
+        List<Comment> comments = commentRepository.findAllByBm(bm);
         Comment comment = comments.get(0);
         assertThat(comment.getMember()).isEqualTo(individual);
         assertThat(comment.getParentComment()).isNull();
-        assertThat(comment.getChildComments().size()).isEqualTo(0);
+        assertThat(commentRepository.findByParentComment(comment).size()).isEqualTo(0);
         assertThat(comment.getContent()).isEqualTo(content);
         assertThat(comment.getBm()).isEqualTo(bm);
     }
 
     @Test
-    @Transactional(propagation = NEVER)
     void 답글_등록_성공() {
         //given
         Member individual = saveIndividual();
@@ -105,10 +104,10 @@ class CommentServiceTest {
         commentService.addComment(bm.getId(), individualMemberDetails, addReplyCommentReq);
 
         //then
-        List<Comment> comments = commentRepository.findByBm(bm);
+        List<Comment> comments = commentRepository.findAllByBm(bm);
         Comment comment = comments.get(0);
 
-        List<Comment> replyComments = comment.getChildComments();
+        List<Comment> replyComments = commentRepository.findByParentComment(parentComment);
         Comment replyComment = replyComments.get(0);
         assertThat(replyComment.getParentComment()).isEqualTo(comment);
         assertThat(replyComment.getContent()).isEqualTo(replyCommentContent);
@@ -153,7 +152,6 @@ class CommentServiceTest {
     }
 
     @Test
-    @Transactional(propagation = NEVER)
     void 답글_포함_댓글_조회_성공() {
         //given
         Member individualA = saveIndividual();
@@ -184,14 +182,13 @@ class CommentServiceTest {
     }
 
     @Test
-    @Transactional(propagation = NEVER)
     @DisplayName("답글이 있는 댓글은 삭제되어도 조회된다.")
     void 삭제된_댓글_조회_성공() {
         //given
         Member individualA = saveIndividual();
         Company company = saveCompany();
         Bm bm = saveBm(company);
-        Comment parentComment = new Comment(individualA, bm, null, "댓글 내용");
+        Comment parentComment = Comment.of(individualA, bm, "댓글 내용");
         parentComment.deleteParentComment();
         commentRepository.save(parentComment);
 
@@ -288,7 +285,6 @@ class CommentServiceTest {
     }
 
     @Test
-    @Transactional(propagation = NEVER)
     @DisplayName("답글이 있는 댓글은 DB에서 삭제되지 않는다.")
     void 답글_있는_댓글_삭제_성공() {
         //given
@@ -363,10 +359,12 @@ class CommentServiceTest {
     }
 
     private Comment saveComment(Member member, Bm bm) {
-        return commentRepository.save(new Comment(member, bm, null, "댓글 내용"));
+        return commentRepository.save(Comment.of(member, bm, "댓글 내용"));
     }
 
     private Comment saveReplyComment(Member member, Comment parentComment, Bm bm) {
-        return commentRepository.save(new Comment(member, bm, parentComment, "답글 내용"));
+        Comment replyComment = commentRepository.save(Comment.of(member, bm, "답글 내용"));
+        replyComment.setParent(parentComment);
+        return replyComment;
     }
 }


### PR DESCRIPTION
## ⭐ Summary

> #167 

<br>

## 📌 Tasks

1. 단순 엔티티 조회는 EntityFacade를 통해 조회하도록 수정 (Bm, Comment, Investment, MySpHistory)
2. 빌더 패턴 제거 및 정적 팩토리 메서드 사용 (Comment, Investment)
3. 댓글 양방향 매핑 제거

댓글을 단방향으로 변경하면 각 댓글마다 대댓글을 조회하는 쿼리를 아래처럼 날려야 해서 리팩토링이 필요할 것 같습니다.
in 절로 조회해와서 서비스 단에서 grouping 해주는 방법이 있는데 코드가 살짝 복잡해질 것 같아요.
아니면 그냥 다시 양방향으로 바꾸고 @BatchSize 사용하는게 깔끔하지 않을까 싶어요

근데 이거 뭔가 더 좋은 방법이 있을 것 같은데... 잘 모르겠네요...ㅠ
일단 리팩토링은 차차 해보는 걸로..

```java
    public List<? extends BaseCommentRes> getComments(Long bmId, MemberDetails memberDetails) {
        Member member = entityFacade.getMember(memberDetails.id());
        Bm bm = entityFacade.getBm(bmId);

        List<Comment> comments = commentRepository.findAllByBm(bm);

        return comments.stream()
                .map(comment -> {
                    //각 comment마다 대댓글 조회하는 쿼리 수행
                    List<ReplyCommentRes> replyCommentResList = commentRepository.findByParentComment(comment).stream()
                            .map(childComment -> ReplyCommentRes.createRes(
                                    childComment, childComment.getMember().getProfileImgKey()
                            ))
                            .toList();
        ...
```

<br>
