### PR TITLE
refactor: app 실행 전 ELK+Filebeat 실행

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -12,6 +12,10 @@ permissions:
     group: ec2-user
 
 hooks:
+  BeforeInstall:
+    - location: scripts/pre_install.sh
+      timeout: 120
+      runas: ec2-user
   AfterInstall:
     - location: scripts/stop.sh
       timeout: 60

--- a/scripts/pre_install.sh
+++ b/scripts/pre_install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+PROJECT_ROOT="/home/ec2-user/app"
+
+cd $PROJECT_ROOT
+
+NEED_RESTART=0
+for CONTAINER in pitchain_filebeat pitchain_logstash pitchain_kibana pitchain_elasticsearch; do
+  if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
+    echo "$CONTAINER 컨테이너가 실행 중이 아닙니다."
+    NEED_RESTART=1
+  fi
+done
+
+if [ $NEED_RESTART -eq 1 ]; then
+  echo "하나 이상의 ELK 컨테이너가 다운되어 있으므로 ELK 및 Filebeat를 재시작합니다."
+  docker-compose --profile setup -f docker-compose-elk.yml up --build -d
+else
+  echo "모든 ELK 컨테이너가 정상적으로 실행 중입니다."
+fi


### PR DESCRIPTION
## ⭐ Summary

> #192

<br>

## 📌 Tasks

1. 배포 환경에서 app 실행 전 ELK+Filebeat 실행

<br>
## ETC
- codedeploy appspec에서 hooks 옵션을 통해 순서를 조정해줄 수 있어서 이를 활용했습니다.
- ELK+Filebeat 중 하나 이상의 컨테이너가 다운된 경우에만 재실행되도록 설정해놨습니다
