### PR TITLE
fix: ApplicationStart hook의 time out 증가

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -18,7 +18,7 @@ hooks:
       runas: ec2-user
   ApplicationStart:
     - location: scripts/start.sh
-      timeout: 60
+      timeout: 180
       runas: ec2-user
   ValidateService:
     - location: scripts/validate.sh


### PR DESCRIPTION
## ⭐ Summary

> #195

<br>

## 📌 Tasks

1. ApplicationStart hook의 timeout 증가

<br>

